### PR TITLE
Remove version numbering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ build:
 	mkdir build
 
 build/%.html: src/%.md
-	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --title-prefix "The OpenJDK Developers' Guide" --include-after-body=src/footer.html | iconv -f UTF-8 -t ISO-8859-1 > $@
-	sed -i "" "/^  <meta charset=/d" $@
+	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --to html4 --title-prefix "The OpenJDK Developers' Guide" --include-after-body=src/footer.html | iconv -f UTF-8 -t ISO-8859-1 > $@
+	perl -pi -e 's/ charset=utf-8//' $@
 
 build/guidestyle.css: build src/guidestyle.css
 	cp src/guidestyle.css build/guidestyle.css

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ build:
 	mkdir build
 
 build/%.html: src/%.md
-	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --to html4 --title-prefix "The OpenJDK Developers' Guide" --include-after-body=src/footer.html | iconv -f UTF-8 -t ISO-8859-1 > $@
+	cp src/footer.html build/tmp_footer.html
+	perl -pi -e 'BEGIN {$$hash=shift} s/!git-commit-hash!/$$hash/' $$(git log -1 --pretty=format:"%H" -- $<) build/tmp_footer.html
+	perl -pi -e 's;!source-file-name!;$<;' build/tmp_footer.html
+	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --to html4 --title-prefix "The OpenJDK Developers' Guide" --include-after-body=build/tmp_footer.html | iconv -f UTF-8 -t ISO-8859-1 > $@
 	perl -pi -e 's/ charset=utf-8//' $@
+	rm build/tmp_footer.html
 
 build/guidestyle.css: build src/guidestyle.css
 	cp src/guidestyle.css build/guidestyle.css

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	mkdir build
 
 build/%.html: src/%.md
-	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --title-prefix "The OpenJDK Developers' Guide" | iconv -f UTF-8 -t ISO-8859-1 > $@
+	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --title-prefix "The OpenJDK Developers' Guide" --include-after-body=src/footer.html | iconv -f UTF-8 -t ISO-8859-1 > $@
 	sed -i "" "/^  <meta charset=/d" $@
 
 build/guidestyle.css: build src/guidestyle.css

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# OpenJDK Developer's Guide
+
+This Project maintains the [OpenJDK Developers' Guide](https://openjdk.java.net/guide/).
+The goal of this guide is to answer questions that the developers of the JDK might have around
+development process, tooling, standards, etc. The formal rules and processes are described in
+other documents, like [JEP 1](https://openjdk.java.net/jeps/1) for the JDK Enhancement-Proposal
+& Roadmap Process, or [JEP 3](https://openjdk.java.net/jeps/3) for the JDK Release Process.
+This guide is meant to be a complement with tutorials and examples for how to follow these rules
+and how to work together with the rest of the OpenJDK community.
+
+There are many common use cases that aren't detailed in the formal process. This guide contains the
+defacto standard for how to work in such cases.
+
+## Audience
+
+The target audience for this document is anyone in the OpenJDK community who aims to contribute
+to the development of OpenJDK. The nature of such a document is to target those who are not
+familiar with the process. People who are regular contributors would already know much of
+what this guide has to offer. Still, the Developers' Guide should work as a source of knowledge also
+for experienced contributors. This means that any descriptions in the Guide should be self-contained
+or have explicit references to any information the reader is expected to already know. The information
+should also be structured in such a way that it's easy to find details for any process, so that
+one who already knows the big picture can quickly find that particular detail that was forgotten.
+
+## Contributing
+
+To engage in the development of the Developers' Guide itself, create a private fork and join
+the dedicated [guide-dev mail list](https://mail.openjdk.java.net/mailman/listinfo/guide-dev).
+
+## Building the Developers' Guide
+
+The project comes with a makefile. Simply type `make` to generate html files from the source
+markdown. The build requires the tools `pandoc`, `ìconv`, and `perl` and assumes a posix environment.
+The resulting html files in the `build` directory are exactly the files published on the
+OpenJDK web server. There is however a larger framework on the web server with fonts and CSS
+that is not part of this project. This means that the html files as they are generated
+will not look exactly the same as the final published version. Still they are hopefully good
+enough to proof read changes and see the layout in a browser.

--- a/src/bugDatabase.md
+++ b/src/bugDatabase.md
@@ -1,19 +1,11 @@
 % Bug Database
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](next.html) • [TOC](index.html) • [Next »](faq.html)
 :::
 
 The Bug Database section will include the guidelines for triage, priorities,
 and status.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](next.html) • [TOC](index.html) • [Next »](faq.html)

--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -1,9 +1,5 @@
 % Change Planning and Guidelines
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](codeConventions.html) • [TOC](index.html) • [Next »](reviewBodies.html)
 :::
@@ -297,10 +293,6 @@ TBD
 This section will describe the process for adding new functionality which
 requires more than just a few new APIs. In particular, this will cover how the
 JSR process interacts with the OpenJDK development life cycle.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](codeConventions.html) • [TOC](index.html) • [Next »](reviewBodies.html)

--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -100,7 +100,7 @@ also imply "implementation for an enhancement".
    |   | unit tests should contain a                                          |
    |   | [\@bug tag](http://openjdk.java.net/jtreg/tag-spec.html#INFORMATIONAL_TAGS9) |
    |   | referencing at least one bugid.                                      |
-   |   |                                                                      |
+   +---+----------------------------------------------------------------------+
    |   | An entirely new test (or tests) may not be required. For             |
    |   | example, if the bug is an existing regression test failure, then     |
    |   | when fixing the bug you should just add the new bug ID to the list   |
@@ -114,67 +114,67 @@ also imply "implementation for an enhancement".
    |   | possibly a comment, to the bug report.  The label has the prefix     |
    |   | "noreg" for regression tests and "nounit" for unit tests.  The       |
    |   | suffixes and their meanings are as follows:                          |
-   |   |                                                                      |
-   |   | **-sqe**                                                             |
+   +---+----------------------------------------------------------------------+
+   |   | <a name="noreg-sqe">**-sqe**</a>                                     |
    |   | :    Change can be verified by running an existing SQE test suite;   |
-   |   |      the bug should identify the suite and the specific test case(s). |
+   |   |      the bug should identify the suite and the specific test case(s).|
    |   |                                                                      |
-   |   | **-jck**                                                             |
+   |   | <a name="noreg-jck">**-jck**</a>                                     |
    |   | :    Change can be verified by running the JCK; the bug should       |
    |   |      identify the specific test case(s).                             |
    |   |                                                                      |
-   |   | **-external**                                                        |
+   |   | <a name="noreg-external">**-external**</a>                           |
    |   | :    Change can be verified by running an existing external test     |
    |   |      suite; the bug should identify the suite and the specific test  |
    |   |      case(s).                                                        |
    |   |                                                                      |
-   |   | **-doc**                                                             |
+   |   | <a name="noreg-doc">**-doc**</a>                                     |
    |   | :    Change only affects documentation.                              |
    |   |                                                                      |
-   |   | **-demo**                                                            |
+   |   | <a name="noreg-demo">**-demo**</a>                                   |
    |   | :    Change only affects demo code.                                  |
    |   |                                                                      |
-   |   | **-build**                                                           |
+   |   | <a name="noreg-build">**-build**</a>                                 |
    |   | :    Change only affects build infrastructure (makefiles,            |
    |   |      copyrights, scripts, etc.).                                     |
    |   |                                                                      |
-   |   | **-self**                                                            |
+   |   | <a name="noreg-self">**-self**</a>                                   |
    |   | :    Change is a fix to a regression or unit test itself.            |
    |   |                                                                      |
-   |   | **-perf**                                                            |
+   |   | <a name="noreg-perf">**-perf**</a>                                   |
    |   | :    Change is for a performance bug for which writing a regression  |
    |   |      test is infeasible; the bug should describe how to verify the   |
    |   |      fix.                                                            |
    |   |                                                                      |
-   |   | **-hard**                                                            |
+   |   | <a name="noreg-hard">**-hard**</a>                                   |
    |   | :    It is too hard to write a regression or unit test for this bug  |
    |   |      (e.g., theoretical race condition, complex setup, reboot        |
    |   |      required, editing of installed files required, specific         |
    |   |      graphics card required); the bug should explain why.            |
    |   |                                                                      |
-   |   | **-long**                                                            |
+   |   | <a name="noreg-long">**-long**</a>                                   |
    |   | :    Testing requires a very long running time (e.g., more than a    |
    |   |      few minutes).                                                   |
    |   |                                                                      |
-   |   | **-big**                                                             |
+   |   | <a name="noreg-big">**-big**</a>                                     |
    |   | :    Testing requires an unreasonable quantity of resources (e.g.,   |
    |   |      tens of gigabytes of filesystem space).                         |
    |   |                                                                      |
-   |   | **-trivial**                                                         |
+   |   | <a name="noreg-trivial">**-trivial**</a>                             |
    |   | :    Change is so trivial that nothing could possibly go wrong with  |
    |   |      it.                                                             |
    |   |                                                                      |
-   |   | **-cleanup**                                                         |
+   |   | <a name="noreg-cleanup">**-cleanup**</a>                             |
    |   | :    Change is a cleanup or refactoring of existing code that is     |
    |   |      covered by existing tests.                                      |
    |   |                                                                      |
-   |   | **-l10n**                                                            |
+   |   | <a name="noreg-l10n">**-l10n**</a>                                   |
    |   | :    Change only affects localized text.                             |
    |   |                                                                      |
-   |   | **-undo**                                                            |
+   |   | <a name="noreg-undo">**-undo**</a>                                   |
    |   | :    Change is a reversion of a previous faulty change.              |
    |   |                                                                      |
-   |   | **-other**                                                           |
+   |   | <a name="noreg-other">**-other**</a>                                 |
    |   | :    Regression or unit test is unnecessary or infeasible for some   |
    |   |      other reason; the bug report should explain why.                |
    |   |                                                                      |

--- a/src/codeConventions.md
+++ b/src/codeConventions.md
@@ -1,19 +1,11 @@
 % Code Conventions
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](mailinglists.html) • [TOC](index.html) • [Next »](changePlanning.html)
 :::
 
 This section will contain a major revision of our antiquated code conventions
 [document](https://www.oracle.com/technetwork/java/codeconvtoc-136057.html).
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](mailinglists.html) • [TOC](index.html) • [Next »](changePlanning.html)

--- a/src/faq.md
+++ b/src/faq.md
@@ -1,9 +1,5 @@
 % Frequently Asked Questions
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](bugDatabase.html) • [TOC](index.html) • [Next »](glossary.html)
 :::
@@ -12,10 +8,6 @@ The FAQ is transient. It should only contain things that have not been
 integrated into the main document. If questions remain in the FAQ over more
 than a few revisions, it will be to provide a pointer to the section in the
 main document which contains the answer.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](bugDatabase.html) • [TOC](index.html) • [Next »](glossary.html)

--- a/src/footer.html
+++ b/src/footer.html
@@ -1,0 +1,5 @@
+<div class="version">
+<script>
+document.write("Page last modified: " + document.lastModified);
+</script>
+</div>

--- a/src/footer.html
+++ b/src/footer.html
@@ -1,5 +1,3 @@
 <div class="version">
-<script>
-document.write("Page last modified: " + document.lastModified);
-</script>
+File change revision: !git-commit-hash! - <a href="https://github.com/openjdk/guide/commits/master/!source-file-name!">Revision history</a>
 </div>

--- a/src/getSource.md
+++ b/src/getSource.md
@@ -1,9 +1,5 @@
 % `get_source.sh` Output
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)
 :::
@@ -105,10 +101,6 @@ version 0.02
 >                 ./hotspot:   searching for changes
 >                 ./hotspot:   no changes found
 >     Waiting 5 secs before spawning next background command.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,9 +1,5 @@
 % Glossary
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](faq.html) • [TOC](index.html)
 :::
@@ -63,10 +59,6 @@ version 0.02
     [`webrev.ksh`](http://hg.openjdk.java.net/code-tools/webrev/raw-file/tip/webrev.ksh),
     examines a forest or repository to generate a set of web-based views of
     differences.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](faq.html) • [TOC](index.html)

--- a/src/hgHelp.md
+++ b/src/hgHelp.md
@@ -1,9 +1,5 @@
 %`hg help` Output
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](repositories.html#verify) • [TOC](index.html) • [Next »](repositories.html#cloneSandbox)
 :::
@@ -92,10 +88,6 @@ version 0.02
 >      urls          URL Paths
 
 >     use "hg -v help" to show builtin aliases and global options
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](repositories.html#verify) • [TOC](index.html) • [Next »](repositories.html#cloneSandbox)

--- a/src/index.md
+++ b/src/index.md
@@ -1,9 +1,5 @@
 % Index
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [Next »](intro.html)
 :::
@@ -33,10 +29,6 @@ version 0.02
 * [Bug Database](bugDatabase.html)
 * [Frequently Asked Questions](faq.html)
 * [Glossary](glossary.html)
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [Next »](intro.html)

--- a/src/intro.md
+++ b/src/intro.md
@@ -1,9 +1,5 @@
 % Introduction
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](index.html) • [TOC](index.html) • [Next »](processWorkflow.html)
 :::
@@ -15,18 +11,6 @@ employees is always a challenge. This document attempts to address the needs of
 developers who wish to participate in the future of the JDK.
 
 Comments may be sent to [guide-dev (at) openjdk.java.net](mailto:guide-dev-at-openjdk.java.net).
-
-
-## Release Notes
-
-Revision   Date         Description
----------  -----------  ------------
-0.02       2012-11-06   Quick pass to remove the obviously incorrect, validate HTML
-0.01       2008-02-14   Initial revision containing the "Repositories", "Change Planning and Guidelines: Fixing a Bug", and "Producing a Changeset" sections.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](index.html) • [TOC](index.html) • [Next »](processWorkflow.html)

--- a/src/jckAcquisition.md
+++ b/src/jckAcquisition.md
@@ -1,19 +1,11 @@
 % JCK Acquisition
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](testingChanges.html) • [TOC](index.html) • [Next »](producingChangeset.html)
 :::
 
 This section will primarily consist of links to the documentation provided by
 the OpenJDK [Conformance Group](../groups/conformance). Tips for when the test suite should be run may be provided.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](testingChanges.html) • [TOC](index.html) • [Next »](producingChangeset.html)

--- a/src/mailingLists.md
+++ b/src/mailingLists.md
@@ -1,9 +1,5 @@
 % Mailing Lists
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](repositories.html) • [TOC](index.html) • [Next »](codeConventions.html)
 :::
@@ -17,10 +13,6 @@ naming conventions, for instance _&ast;-dev_ and
 _&ast;-discuss_ and other suffixes such as those for code
 review requests, changeset notifications, and automatic bug updates as these
 services become available.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](repositories.html) • [TOC](index.html) • [Next »](codeConventions.html)

--- a/src/next.md
+++ b/src/next.md
@@ -1,19 +1,11 @@
 % What Happens Next
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](producingChangeset.html) • [TOC](index.html) • [Next »](bugDatabase.html)
 :::
 
 This section describes what might happen after a changeset gets into the build,
 for example a bug might be filed or a backport could be requested.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](producingChangeset.html) • [TOC](index.html) • [Next »](bugDatabase.html)

--- a/src/processWorkflow.md
+++ b/src/processWorkflow.md
@@ -1,9 +1,5 @@
 % Process Workflow
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](intro.html) • [TOC](index.html) • [Next »](repositories.html)
 :::
@@ -12,10 +8,6 @@ This is the main navigation for the document and the primary entry point. It is
 intended to be a quick start and overview which will have a hyperlinked diagram
 indicating sample work flows for common operations such as submitting a bug fix
 and adding a new API.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](intro.html) • [TOC](index.html) • [Next »](repositories.html)

--- a/src/producingChangeset.md
+++ b/src/producingChangeset.md
@@ -1,9 +1,5 @@
 % Producing a Changeset
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](jckAcquisition.html) • [TOC](index.html) • [Next »](next.html)
 :::
@@ -402,10 +398,6 @@ dedicated _-changes_ list for notifications.
 > information about becoming a Project Committer.
 
 > ---
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](jckAcquisition.html) • [TOC](index.html) • [Next »](next.html)

--- a/src/repositories.md
+++ b/src/repositories.md
@@ -1,9 +1,5 @@
 % Repositories
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](processWorkflow.html) • [TOC](index.html) • [Next »](mailingLists.html)
 :::
@@ -260,10 +256,6 @@ destination directory.
 >     6212 files updated, 0 files merged, 0 files removed, 0 files unresolved
 >     $ du -s langtools
 >     84396   langtools
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](processWorkflow.html) • [TOC](index.html) • [Next »](mailingLists.html)

--- a/src/reviewBodies.md
+++ b/src/reviewBodies.md
@@ -1,9 +1,5 @@
 % Review Bodies
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](changePlanning.html) • [TOC](index.html) • [Next »](testingChanges.html)
 :::
@@ -11,10 +7,6 @@ version 0.02
 For now, this corresponds to the current processes referred to as
 [_JEP_](http://openjdk.java.net/jeps/0)
 and _ccc_. Other processes may be identified later.
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](changePlanning.html) • [TOC](index.html) • [Next »](testingChanges.html)

--- a/src/tClone.md
+++ b/src/tClone.md
@@ -1,9 +1,5 @@
 %`tclone` Output
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)
 :::
@@ -89,10 +85,6 @@ version 0.02
 >     updating to branch default
 >     2121 files updated, 0 files merged, 0 files removed, 0 files unresolved
 >     created /home/iris/9dev/nashorn
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)

--- a/src/testingChanges.md
+++ b/src/testingChanges.md
@@ -1,9 +1,5 @@
 % Testing Changes
 
-::: {.version}
-version 0.02
-:::
-
 ::: {.NavBit}
 [« Previous](reviewBodies.html) • [TOC](index.html) • [Next »](jckAcquisition.html)
 :::
@@ -17,10 +13,6 @@ tests. Characteristics of a good regression test will be provided.
  See also the <a href="http://openjdk.java.net/groups/quality/">OpenJDK
 Quality Group</a>. 
 -->
-
-::: {.version}
-version 0.02
-:::
 
 ::: {.NavBit}
 [« Previous](reviewBodies.html) • [TOC](index.html) • [Next »](jckAcquisition.html)


### PR DESCRIPTION
Removed release notes and version numbers from all pages. Added a footer which displays file modification date and time instead. The modification time is currently only placed at the bottom of each file, while the version number was present both at the top and at the bottom. This was made on purpose. Please leave a comment if you disagree with that decision. It's a simple makefile change to add it at the top as well.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Iris Clark ([iris](@irisclark) - **Reviewer**)
 * Magnus Ihse Bursie ([ihse](@magicus) - no project role)

### Download
`$ git fetch https://git.openjdk.java.net/guide pull/9/head:pull/9`
`$ git checkout pull/9`
