### PR TITLE
Usign perl instead of sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ build:
 	mkdir build
 
 build/%.html: src/%.md
-	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --title-prefix "The OpenJDK Developers' Guide" | iconv -f UTF-8 -t ISO-8859-1 > $@
-	perl -ni -e 'print unless /.*<meta charset=.*/' $@
+	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --to html4 --title-prefix "The OpenJDK Developers' Guide" | iconv -f UTF-8 -t ISO-8859-1 > $@
+	perl -pi -e 's/ charset=utf-8//' $@
 
 build/guidestyle.css: build src/guidestyle.css
 	cp src/guidestyle.css build/guidestyle.css

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 
 build/%.html: src/%.md
 	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --title-prefix "The OpenJDK Developers' Guide" | iconv -f UTF-8 -t ISO-8859-1 > $@
-	sed -i "" "/^  <meta charset=/d" $@
+	perl -ni -e 'print unless /.*<meta charset=.*/' $@
 
 build/guidestyle.css: build src/guidestyle.css
 	cp src/guidestyle.css build/guidestyle.css


### PR DESCRIPTION
It turns out that different common versions of sed behaves differently so the suggestion here is to replace it with perl.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Iris Clark ([iris](@irisclark) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/guide pull/10/head:pull/10`
`$ git checkout pull/10`
