### PR TITLE
Markdown anchors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 
 build/%.html: src/%.md
 	cp src/footer.html build/tmp_footer.html
-	perl -pi -e 'BEGIN {$$hash=shift} s/!git-commit-hash!/$$hash/' $$(git log -1 --pretty=format:"%H" -- $<) build/tmp_footer.html
+	perl -pi -e 'BEGIN {$$hash=shift} s/!git-commit-hash!/$$hash/' $$(git log -1 --pretty=format:"%h" -- $<) build/tmp_footer.html
 	perl -pi -e 's;!source-file-name!;$<;' build/tmp_footer.html
 	pandoc $< --css guidestyle.css --strip-comments --standalone --ascii --to html4 --title-prefix "The OpenJDK Developers' Guide" --include-after-body=build/tmp_footer.html | iconv -f UTF-8 -t ISO-8859-1 > $@
 	perl -pi -e 's/ charset=utf-8//' $@

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the dedicated [guide-dev mail list](https://mail.openjdk.java.net/mailman/listin
 ## Building the Developers' Guide
 
 The project comes with a makefile. Simply type `make` to generate html files from the source
-markdown. The build requires the tools `pandoc`, `ìconv`, and `perl` and assumes a posix environment.
+markdown. The build requires the tools `pandoc`, `iconv`, and `perl` and assumes a posix environment.
 The resulting html files in the `build` directory are exactly the files published on the
 OpenJDK web server. There is however a larger framework on the web server with fonts and CSS
 that is not part of this project. This means that the html files as they are generated

--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -115,66 +115,66 @@ also imply "implementation for an enhancement".
    |   | "noreg" for regression tests and "nounit" for unit tests.  The       |
    |   | suffixes and their meanings are as follows:                          |
    +---+----------------------------------------------------------------------+
-   |   | <a name="noreg-sqe">**-sqe**</a>                                     |
+   |   | [**-sqe**]{#noreg-sqe}                                               |
    |   | :    Change can be verified by running an existing SQE test suite;   |
    |   |      the bug should identify the suite and the specific test case(s).|
    |   |                                                                      |
-   |   | <a name="noreg-jck">**-jck**</a>                                     |
+   |   | [**-jck**]{#noreg-jck}                                               |
    |   | :    Change can be verified by running the JCK; the bug should       |
    |   |      identify the specific test case(s).                             |
    |   |                                                                      |
-   |   | <a name="noreg-external">**-external**</a>                           |
+   |   | [**-external**]{#noreg-external}                                     |
    |   | :    Change can be verified by running an existing external test     |
    |   |      suite; the bug should identify the suite and the specific test  |
    |   |      case(s).                                                        |
    |   |                                                                      |
-   |   | <a name="noreg-doc">**-doc**</a>                                     |
+   |   | [**-doc**]{#noreg-doc}                                               |
    |   | :    Change only affects documentation.                              |
    |   |                                                                      |
-   |   | <a name="noreg-demo">**-demo**</a>                                   |
+   |   | [**-demo**]{#noreg-demo}                                             |
    |   | :    Change only affects demo code.                                  |
    |   |                                                                      |
-   |   | <a name="noreg-build">**-build**</a>                                 |
+   |   | [**-build**<]{#noreg-build}                                          |
    |   | :    Change only affects build infrastructure (makefiles,            |
    |   |      copyrights, scripts, etc.).                                     |
    |   |                                                                      |
-   |   | <a name="noreg-self">**-self**</a>                                   |
+   |   | [**-self**]{#noreg-self}                                             |
    |   | :    Change is a fix to a regression or unit test itself.            |
    |   |                                                                      |
-   |   | <a name="noreg-perf">**-perf**</a>                                   |
+   |   | [**-perf**]{#noreg-perf}                                             |
    |   | :    Change is for a performance bug for which writing a regression  |
    |   |      test is infeasible; the bug should describe how to verify the   |
    |   |      fix.                                                            |
    |   |                                                                      |
-   |   | <a name="noreg-hard">**-hard**</a>                                   |
+   |   | [**-hard**]{#noreg-hard}                                             |
    |   | :    It is too hard to write a regression or unit test for this bug  |
    |   |      (e.g., theoretical race condition, complex setup, reboot        |
    |   |      required, editing of installed files required, specific         |
    |   |      graphics card required); the bug should explain why.            |
    |   |                                                                      |
-   |   | <a name="noreg-long">**-long**</a>                                   |
+   |   | [**-long**]{#noreg-long}                                             |
    |   | :    Testing requires a very long running time (e.g., more than a    |
    |   |      few minutes).                                                   |
    |   |                                                                      |
-   |   | <a name="noreg-big">**-big**</a>                                     |
+   |   | [**-big**]{#noreg-big}                                               |
    |   | :    Testing requires an unreasonable quantity of resources (e.g.,   |
    |   |      tens of gigabytes of filesystem space).                         |
    |   |                                                                      |
-   |   | <a name="noreg-trivial">**-trivial**</a>                             |
+   |   | [**-trivial**]{#noreg-trivial}                                       |
    |   | :    Change is so trivial that nothing could possibly go wrong with  |
    |   |      it.                                                             |
    |   |                                                                      |
-   |   | <a name="noreg-cleanup">**-cleanup**</a>                             |
+   |   | [**-cleanup**]{#noreg-cleanup}                                       |
    |   | :    Change is a cleanup or refactoring of existing code that is     |
    |   |      covered by existing tests.                                      |
    |   |                                                                      |
-   |   | <a name="noreg-l10n">**-l10n**</a>                                   |
+   |   | [**-l10n**]{#noreg-l10n}                                             |
    |   | :    Change only affects localized text.                             |
    |   |                                                                      |
-   |   | <a name="noreg-undo">**-undo**</a>                                   |
+   |   | [**-undo**]{#noreg-undo}                                             |
    |   | :    Change is a reversion of a previous faulty change.              |
    |   |                                                                      |
-   |   | <a name="noreg-other">**-other**</a>                                 |
+   |   | [**-other**]{#noreg-other}                                           |
    |   | :    Regression or unit test is unnecessary or infeasible for some   |
    |   |      other reason; the bug report should explain why.                |
    |   |                                                                      |

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -4,25 +4,25 @@
 [« Previous](faq.html) • [TOC](index.html)
 :::
 
-**accepted** (by the CCC)
+[**accepted**]{#accepted} (by the CCC)
 :   The stage of the CCC process after "DRAFT", and "PROPOSED". At this stage the
     primary goals are to ensure that the proposed changes are suitable for the
     release in a general sense and that the requisite JCK and SQE resources will be
     available.
 
-**approved** (by the CCC)
+[**approved**]{#approved} (by the CCC)
 :   The stage of the CCC process after "FINAL". The CCC has approved the final
    version of the request which permits push into the project forest.
 
-**changeset**
+[**changeset**]{#changeset}
 :   A collection of changes with respect to the current clone of a repository.
 
-**development freeze**
+[**development freeze**]{#developmentfreeze}
 :   The date by which all planned work should be complete for a particular line of
     development. After a line's development freeze, only exit-criteria bugs may be
     fixed in that line.
 
-**forest**
+[**forest**]{#forest}
 :   A collection of Mercurial repositories which can be managed as a set of nested
     repositories. The name "Forest" originally came from the Mercurial "Forest
     Extension" which can be used with some versions of Mercurial, but in general is
@@ -31,30 +31,30 @@
     Mercurial `hg` command to all the repositories in
     a forest.
 
-**Group**
+[**Group**]{#group}
 :   A collection of [Participants](/bylaws#participant) who engage in
     open conversation about a common interest. That interest may be in the
     creation, enhancement, or maintenance of a specific body of code or it may lie
     in other areas, e.g., quality, documentation, or evangelism. See the
     [Group overview](../groups/).
 
-**Mercurial**
+[**Mercurial**]{#mercurial}
 :   A free, cross-platform, distributed source management tool. Source bundles and
     binary packages for Mercurial are available at
     [http://www.selenic.com/mercurial/wiki/index.cgi](http://www.selenic.com/mercurial/wiki/index.cgi/Mercurial).
     The main Mercurial documentation is available at
     [http://hgbook.red-bean.com](http://hgbook.red-bean.com/).
 
-**Project**
+[**Project**]{#project}
 :   A collaborative effort to produce a specific artifact, which may be a body of
     code, or documentation, or some other material. See the
     [Project overview](../projects/).
 
-**repository**
+[**repository**]{#repository}
 :   A directory tree in the filesystem that Mercurial treats specially. This tree
    contains the source files and their revision history.
 
-**webrev**
+[**webrev**]{#webrev}
 :   A tool and its output. In JDK release forests, the script,
     [`webrev.ksh`](http://hg.openjdk.java.net/code-tools/webrev/raw-file/tip/webrev.ksh),
     examines a forest or repository to generate a set of web-based views of


### PR DESCRIPTION
Found how to do link anchors in markdown. Added anchors in the glossary as well. Also changed to short hash in the footer, the long hash took over the whole page in the final published version.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Magnus Ihse Bursie ([ihse](@magicus) - no project role)
 * Iris Clark ([iris](@irisclark) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/guide pull/13/head:pull/13`
`$ git checkout pull/13`
