### PR TITLE
Added anchor for noreg table

### DIFF
--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -90,7 +90,7 @@ also imply "implementation for an enhancement".
    working on the code using the latest source available from the appropriate
    OpenJDK Project [repository](http://hg.openjdk.java.net).
 
-#. **Is it possible to write a test to detect the bug?**
+#. [**Is it possible to write a test to detect the bug?**]{#noreg}
 
    +:-:+:---------------------------------------------------------------------+
    | Y | For bugs, provide a [jtreg](../jtreg/) regression test               |

--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -134,7 +134,7 @@ also imply "implementation for an enhancement".
    |   | [**-demo**]{#noreg-demo}                                             |
    |   | :    Change only affects demo code.                                  |
    |   |                                                                      |
-   |   | [**-build**<]{#noreg-build}                                          |
+   |   | [**-build**]{#noreg-build}                                           |
    |   | :    Change only affects build infrastructure (makefiles,            |
    |   |      copyrights, scripts, etc.).                                     |
    |   |                                                                      |


### PR DESCRIPTION
On request, adding an anchor to allow for links to the noreg-table. The link will be https://openjdk.java.net/guide/changePlanning.html#noreg
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Iris Clark ([iris](@irisclark) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/guide pull/16/head:pull/16`
`$ git checkout pull/16`
