### PR TITLE
Copy edits, terminology fixes, and factual corrections to the README and the introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to the development of the JDK but is not yet
 familiar with the process. People who are already regular contributors will already know much of
 what this guide has to offer. Still, the Developers' Guide should work as a source of knowledge also
 for experienced contributors. Any descriptions in the Guide should thus be self-contained
-or have explicit references to any information thata the reader is expected to already know. The information
+or have explicit references to any information that the reader is expected to already know. The information
 should also be structured in such a way that it's easy to find the details for any process, so that
 a reader who already knows the big picture can quickly find a particular detail that was forgotten.
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# OpenJDK Developer's Guide
+# OpenJDK Developers' Guide
 
 This Project maintains the [OpenJDK Developers' Guide](https://openjdk.java.net/guide/).
-The goal of this guide is to answer questions that the developers of the JDK might have around
-development process, tooling, standards, etc. The formal rules and processes are described in
-other documents, like [JEP 1](https://openjdk.java.net/jeps/1) for the JDK Enhancement-Proposal
-& Roadmap Process, or [JEP 3](https://openjdk.java.net/jeps/3) for the JDK Release Process.
-This guide is meant to be a complement with tutorials and examples for how to follow these rules
-and how to work together with the rest of the OpenJDK community.
+The goal of this guide is to answer questions that developers of the JDK might have around
+development process, tooling, standards, and so forth. The formal rules and processes are described in
+other documents, such as [JEP 1](https://openjdk.java.net/jeps/1) for the JDK Enhancement-Proposal
+& Roadmap Process, and [JEP 3](https://openjdk.java.net/jeps/3) for the JDK Release Process.
+This guide is meant to be a complement to such documents, with tutorials and examples
+for how to follow these rules and how to work together with the rest of the OpenJDK Community.
 
-There are many common use cases that aren't detailed in the formal process. This guide contains the
-defacto standard for how to work in such cases.
+There are many common use cases that aren't detailed in the formal process. This guide suggests
+how to work in such cases.
 
 ## Audience
 
-The target audience for this document is anyone in the OpenJDK community who aims to contribute
-to the development of OpenJDK. The nature of such a document is to target those who are not
-familiar with the process. People who are regular contributors would already know much of
+The target audience for this document is anyone in the OpenJDK Community who aims to contribute
+to the development of the JDK but is not yet
+familiar with the process. People who are already regular contributors will already know much of
 what this guide has to offer. Still, the Developers' Guide should work as a source of knowledge also
-for experienced contributors. This means that any descriptions in the Guide should be self-contained
-or have explicit references to any information the reader is expected to already know. The information
-should also be structured in such a way that it's easy to find details for any process, so that
-one who already knows the big picture can quickly find that particular detail that was forgotten.
+for experienced contributors. Any descriptions in the Guide should thus be self-contained
+or have explicit references to any information thata the reader is expected to already know. The information
+should also be structured in such a way that it's easy to find the details for any process, so that
+a reader who already knows the big picture can quickly find a particular detail that was forgotten.
 
 ## Contributing
 
@@ -29,10 +29,11 @@ the dedicated [guide-dev mail list](https://mail.openjdk.java.net/mailman/listin
 
 ## Building the Developers' Guide
 
-The project comes with a makefile. Simply type `make` to generate html files from the source
-markdown. The build requires the tools `pandoc`, `iconv`, and `perl` and assumes a posix environment.
-The resulting html files in the `build` directory are exactly the files published on the
-OpenJDK web server. There is however a larger framework on the web server with fonts and CSS
-that is not part of this project. This means that the html files as they are generated
+The project comes with a `Makefile`. Simply type `make` to generate HTML files from the source
+Markdown. The build requires the tools `pandoc`, `iconv`, and `perl` and assumes a POSIX environment.
+The resulting HTML files in the `build` directory are exactly the files published on the
+[OpenJDK web server](https://openjdk.java.net/guide/). There is, however, a larger framework
+on the web server with fonts and CSS
+that is not part of this project. This means that the HTML files as they are generated
 will not look exactly the same as the final published version. Still they are hopefully good
 enough to proof read changes and see the layout in a browser.

--- a/src/intro.md
+++ b/src/intro.md
@@ -6,29 +6,29 @@
 
 Welcome to the OpenJDK Developers' Guide!
 
-OpenJDK is the place to collaborate on an open-source implementation
-of the Java Platform, Standard Edition, and related projects.
-OpenJDK was created when the JDK was first released under the GPLv2 license in May
-2007 and since then a community has grown around it to help develop and maintain Java.
+The OpenJDK Community is the place to collaborate on open-source implementations
+of the Java Platform, Standard Edition, and related projects.  It was created in
+November 2006, when initial portions of the JDK source code were published under
+the GPLv2 license.
 
-In order to work together efficiently clear directions are sometimes needed to
+In order to work together efficiently, clear directions are sometimes needed to
 avoid misconceptions and to align developers' views of terminology and process.
-The OpenJDK community is a fairly pragmatic place. "Do what's right" is most
+The OpenJDK Community is a fairly pragmatic place. "Do the right thing" is most
 often the right course of action. Still, if people do things in the same right way
-everyone's work becomes more transparent and easier for others to follow. For
+then everyone's work becomes more transparent and easier for others to follow. For
 this reason most parts of the development process have standard flows that are the
 recommended ways to do things.
 
-The goal of this guide is to answer questions that the developers of the JDK might
-have around development process, tooling, standards, etc. The formal rules and
-processes are described in other documents, like [JEP 1](https://openjdk.java.net/jeps/1)
-for the JDK Enhancement-Proposal & Roadmap Process, or [JEP 3](https://openjdk.java.net/jeps/3)
-for the JDK Release Process. This guide is meant to be a complement with tutorials
-and examples for how to follow these rules and how to work together with the rest
-of the OpenJDK community.
+The goal of this guide is to answer questions that developers of the JDK might
+have around development process, tooling, standards, and so forth. The formal rules and
+processes are described in other documents, such as [JEP 1](https://openjdk.java.net/jeps/1)
+for the JDK Enhancement-Proposal & Roadmap Process, and [JEP 3](https://openjdk.java.net/jeps/3)
+for the JDK Release Process. This guide is meant to be a complement to such documents,
+with tutorials and examples for how to follow these rules and how to work together with the rest
+of the OpenJDK Community.
 
 There are many common use cases that aren't detailed in the formal process. This
-guide contains the defacto standard for how to work in such cases.
+guide suggests how to work in such cases.
 
 ::: {.NavBit}
 [« Previous](index.html) • [TOC](index.html) • [Next »](processWorkflow.html)


### PR DESCRIPTION
- Change “OpenJDK community” to “OpenJDK Community”
- Omit needless words
- s/like/such as/g
- Fix various typos and grammatical errors
- Tone down “contains the defacto standard” to “suggests”
- The OpenJDK Community was launched in November 2006, not May 2007
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jesper Wilhelmsson ([jwilhelm](@JesperIRL) - **Reviewer**) ⚠️ Review applies to 0a3f8b2512f2a76b5776bd6f9b1084fbb26efa02


### Download
`$ git fetch https://git.openjdk.java.net/guide pull/18/head:pull/18`
`$ git checkout pull/18`
