### PR TITLE
Removed blockquote formatting for code blocks.

### DIFF
--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -47,7 +47,7 @@ also imply "implementation for an enhancement".
    Send an e-mail to the appropriate development mailing list for the Project that
    maintains the code. The e-mail should have a subject line of the form:
 
-   >     6543210: My favorite bug
+       6543210: My favorite bug
 
    where `6543210` is replaced with the actual bug id number or
    "[NEW BUG]" if the bug id is not known and `My favorite bug` is

--- a/src/codeReview.md
+++ b/src/codeReview.md
@@ -53,8 +53,8 @@ For more information about webrev, refer to:
 * For clarity, they add the bug ID they are working on, and
   perhaps add a sequence number:
 
->>     mkdir 6543210
->>     mv webrev 6543210/webrev.00
+      mkdir 6543210
+      mv webrev 6543210/webrev.00
 
   This will allow subsequent webrevs (if there are any) to be
   added as webrev.01 and so on without clobbering the original
@@ -64,8 +64,8 @@ For more information about webrev, refer to:
   the [Atom feed](http://cr.openjdk.java.net/feed.atom),
   create `.title` and/or `.description` files:
 
->>     echo "A suitable review title or bug synopsis" > 6543210/.title
->>     echo "Short description of the change to be reviewed" > 6543210/.description
+      echo "A suitable review title or bug synopsis" > 6543210/.title
+      echo "Short description of the change to be reviewed" > 6543210/.description
 
   Syndication does not recognize line endings or formatting tags,
   so it would be a good idea to keep the information in these files
@@ -79,11 +79,11 @@ For more information about webrev, refer to:
 * They transfer the webrev tree to their home directory on
   cr.openjdk.java.net using scp or rsync:
 
->>     scp -r 6543210 username@cr.openjdk.java.net:
+      scp -r 6543210 username@cr.openjdk.java.net:
 
-> or
+  or
 
->>     rsync -av 6543210 username@cr.openjdk.java.net:
+      rsync -av 6543210 username@cr.openjdk.java.net:
 
   Note the final : on the command line. If you omit that, you will
   copy the bits into a directory called
@@ -91,7 +91,7 @@ For more information about webrev, refer to:
 
 * The results will be published at:
 
->>     http://cr.openjdk.java.net/~username/6543210
+      http://cr.openjdk.java.net/~username/6543210
 
 * In ten minutes or less, the new information will appear on the
   feed:
@@ -101,14 +101,14 @@ For more information about webrev, refer to:
 * Later on, if it is time to clean up, use sftp to access your
   code review directory:
 
->>     sftp username@cr.openjdk.java.net
+      sftp username@cr.openjdk.java.net
 
   Use the `rm` command to delete individual files. If you
   want to delete a tree of files and directories, use the
   `rename` command to move them into your ~/.trash
   subdirectory. To continue with the example for bug ID 6543210:
 
->>     rename 6543210 .trash/6543210
+      rename 6543210 .trash/6543210
 
   A cron job on the cr.openjdk.java.net
   server will periodically empty the trash for

--- a/src/getSource.md
+++ b/src/getSource.md
@@ -4,103 +4,103 @@
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)
 :::
 
->     $ sh ./get_source.sh
->     # Repositories:  corba jaxp jaxws langtools jdk hotspot nashorn
->
->                     corba:   hg clone http://hg.openjdk.java.net/jdk9/dev/corba corba
->                      jaxp:   hg clone http://hg.openjdk.java.net/jdk9/dev/jaxp jaxp
->                      jaxp:   requesting all changes
->                     corba:   requesting all changes
->                      jaxp:   adding changesets
->                     corba:   adding changesets
->                     corba:   adding manifests
->                      jaxp:   adding manifests
->                     corba:   adding file changes
->                      jaxp:   adding file changes
->     Waiting 5 secs before spawning next background command.
->                     corba:   added 567 changesets with 3577 changes to 1398 files
->                     corba:   updating to branch default
->                     corba:   1195 files updated, 0 files merged, 0 files removed, 0 files unresolved
->                     jaxws:   hg clone http://hg.openjdk.java.net/jdk9/dev/jaxws jaxws
->                 langtools:   hg clone http://hg.openjdk.java.net/jdk9/dev/langtools langtools
->                     jaxws:   requesting all changes
->                 langtools:   requesting all changes
->                     jaxws:   adding changesets
->                 langtools:   adding changesets
->                     jaxws:   adding manifests
->                      jaxp:   added 570 changesets with 6285 changes to 4230 files
->                      jaxp:   updating to branch default
->     Waiting 5 secs before spawning next background command.
->                     jaxws:   adding file changes
->                      jaxp:   2078 files updated, 0 files merged, 0 files removed, 0 files unresolved
->                 langtools:   adding manifests
->                 langtools:   adding file changes
->                       jdk:   hg clone http://hg.openjdk.java.net/jdk9/dev/jdk jdk
->                   hotspot:   hg clone http://hg.openjdk.java.net/jdk9/dev/hotspot hotspot
->                   hotspot:   requesting all changes
->                       jdk:   requesting all changes
->                   hotspot:   adding changesets
->                       jdk:   adding changesets
->     Waiting 5 secs before spawning next background command.
->                   hotspot:   adding manifests
->                   nashorn:   hg clone http://hg.openjdk.java.net/jdk9/dev/nashorn nashorn
->                   nashorn:   requesting all changes
->                   nashorn:   adding changesets
->                   nashorn:   adding manifests
->                   nashorn:   adding file changes
->                   hotspot:   adding file changes
->                   nashorn:   added 766 changesets with 6302 changes to 2248 files
->                   nashorn:   updating to branch default
->                   nashorn:   2121 files updated, 0 files merged, 0 files removed, 0 files unresolved
->                     jaxws:   added 471 changesets with 15683 changes to 6727 files
->                     jaxws:   updating to branch default
->                       jdk:   adding manifests
->                 langtools:   added 2326 changesets with 21344 changes to 7022 files
->                     jaxws:   3710 files updated, 0 files merged, 0 files removed, 0 files unresolved
->                 langtools:   updating to branch default
->                 langtools:   6212 files updated, 0 files merged, 0 files removed, 0 files unresolved
->                   hotspot:   added 5876 changesets with 35016 changes to 5071 files
->                   hotspot:   updating to branch default
->                   hotspot:   4183 files updated, 0 files merged, 0 files removed, 0 files unresolved
->                       jdk:   adding file changes
->                       jdk:   added 9280 changesets with 86814 changes to 26475 files
->                       jdk:   updating to branch default
->                       jdk:   22161 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     # Repositories:  ./corba . ./hotspot ./jaxp ./jaxws ./jdk ./langtools ./nashorn
->
->                   ./corba:   cd ./corba && hg pull -u
->                         .:   cd . && hg pull -u
->                 ./hotspot:   cd ./hotspot && hg pull -u
->                    ./jaxp:   cd ./jaxp && hg pull -u
->                   ./jaxws:   cd ./jaxws && hg pull -u
->                     ./jdk:   cd ./jdk && hg pull -u
->               ./langtools:   cd ./langtools && hg pull -u
->                 ./nashorn:   cd ./nashorn && hg pull -u
->                   ./corba:   pulling from http://hg.openjdk.java.net/jdk9/dev/corba
->                         .:   pulling from http://hg.openjdk.java.net/jdk9/dev
->                   ./jaxws:   pulling from http://hg.openjdk.java.net/jdk9/dev/jaxws
->                   ./corba:   searching for changes
->                   ./corba:   no changes found
->                     ./jdk:   pulling from http://hg.openjdk.java.net/jdk9/dev/jdk
->                 ./nashorn:   pulling from http://hg.openjdk.java.net/jdk9/dev/nashorn
->                         .:   searching for changes
->                         .:   no changes found
->                   ./jaxws:   searching for changes
->                   ./jaxws:   no changes found
->               ./langtools:   pulling from http://hg.openjdk.java.net/jdk9/dev/langtools
->                 ./nashorn:   searching for changes
->                 ./nashorn:   no changes found
->                     ./jdk:   searching for changes
->                     ./jdk:   no changes found
->               ./langtools:   searching for changes
->               ./langtools:   no changes found
->                    ./jaxp:   pulling from http://hg.openjdk.java.net/jdk9/dev/jaxp
->                 ./hotspot:   pulling from http://hg.openjdk.java.net/jdk9/dev/hotspot
->                    ./jaxp:   searching for changes
->                    ./jaxp:   no changes found
->                 ./hotspot:   searching for changes
->                 ./hotspot:   no changes found
->     Waiting 5 secs before spawning next background command.
+    $ sh ./get_source.sh
+    # Repositories:  corba jaxp jaxws langtools jdk hotspot nashorn
+
+                    corba:   hg clone http://hg.openjdk.java.net/jdk9/dev/corba corba
+                     jaxp:   hg clone http://hg.openjdk.java.net/jdk9/dev/jaxp jaxp
+                     jaxp:   requesting all changes
+                    corba:   requesting all changes
+                     jaxp:   adding changesets
+                    corba:   adding changesets
+                    corba:   adding manifests
+                     jaxp:   adding manifests
+                    corba:   adding file changes
+                     jaxp:   adding file changes
+    Waiting 5 secs before spawning next background command.
+                    corba:   added 567 changesets with 3577 changes to 1398 files
+                    corba:   updating to branch default
+                    corba:   1195 files updated, 0 files merged, 0 files removed, 0 files unresolved
+                    jaxws:   hg clone http://hg.openjdk.java.net/jdk9/dev/jaxws jaxws
+                langtools:   hg clone http://hg.openjdk.java.net/jdk9/dev/langtools langtools
+                    jaxws:   requesting all changes
+                langtools:   requesting all changes
+                    jaxws:   adding changesets
+                langtools:   adding changesets
+                    jaxws:   adding manifests
+                     jaxp:   added 570 changesets with 6285 changes to 4230 files
+                     jaxp:   updating to branch default
+    Waiting 5 secs before spawning next background command.
+                    jaxws:   adding file changes
+                     jaxp:   2078 files updated, 0 files merged, 0 files removed, 0 files unresolved
+                langtools:   adding manifests
+                langtools:   adding file changes
+                      jdk:   hg clone http://hg.openjdk.java.net/jdk9/dev/jdk jdk
+                  hotspot:   hg clone http://hg.openjdk.java.net/jdk9/dev/hotspot hotspot
+                  hotspot:   requesting all changes
+                      jdk:   requesting all changes
+                  hotspot:   adding changesets
+                      jdk:   adding changesets
+    Waiting 5 secs before spawning next background command.
+                  hotspot:   adding manifests
+                  nashorn:   hg clone http://hg.openjdk.java.net/jdk9/dev/nashorn nashorn
+                  nashorn:   requesting all changes
+                  nashorn:   adding changesets
+                  nashorn:   adding manifests
+                  nashorn:   adding file changes
+                  hotspot:   adding file changes
+                  nashorn:   added 766 changesets with 6302 changes to 2248 files
+                  nashorn:   updating to branch default
+                  nashorn:   2121 files updated, 0 files merged, 0 files removed, 0 files unresolved
+                    jaxws:   added 471 changesets with 15683 changes to 6727 files
+                    jaxws:   updating to branch default
+                      jdk:   adding manifests
+                langtools:   added 2326 changesets with 21344 changes to 7022 files
+                    jaxws:   3710 files updated, 0 files merged, 0 files removed, 0 files unresolved
+                langtools:   updating to branch default
+                langtools:   6212 files updated, 0 files merged, 0 files removed, 0 files unresolved
+                  hotspot:   added 5876 changesets with 35016 changes to 5071 files
+                  hotspot:   updating to branch default
+                  hotspot:   4183 files updated, 0 files merged, 0 files removed, 0 files unresolved
+                      jdk:   adding file changes
+                      jdk:   added 9280 changesets with 86814 changes to 26475 files
+                      jdk:   updating to branch default
+                      jdk:   22161 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    # Repositories:  ./corba . ./hotspot ./jaxp ./jaxws ./jdk ./langtools ./nashorn
+
+                  ./corba:   cd ./corba && hg pull -u
+                        .:   cd . && hg pull -u
+                ./hotspot:   cd ./hotspot && hg pull -u
+                   ./jaxp:   cd ./jaxp && hg pull -u
+                  ./jaxws:   cd ./jaxws && hg pull -u
+                    ./jdk:   cd ./jdk && hg pull -u
+              ./langtools:   cd ./langtools && hg pull -u
+                ./nashorn:   cd ./nashorn && hg pull -u
+                  ./corba:   pulling from http://hg.openjdk.java.net/jdk9/dev/corba
+                        .:   pulling from http://hg.openjdk.java.net/jdk9/dev
+                  ./jaxws:   pulling from http://hg.openjdk.java.net/jdk9/dev/jaxws
+                  ./corba:   searching for changes
+                  ./corba:   no changes found
+                    ./jdk:   pulling from http://hg.openjdk.java.net/jdk9/dev/jdk
+                ./nashorn:   pulling from http://hg.openjdk.java.net/jdk9/dev/nashorn
+                        .:   searching for changes
+                        .:   no changes found
+                  ./jaxws:   searching for changes
+                  ./jaxws:   no changes found
+              ./langtools:   pulling from http://hg.openjdk.java.net/jdk9/dev/langtools
+                ./nashorn:   searching for changes
+                ./nashorn:   no changes found
+                    ./jdk:   searching for changes
+                    ./jdk:   no changes found
+              ./langtools:   searching for changes
+              ./langtools:   no changes found
+                   ./jaxp:   pulling from http://hg.openjdk.java.net/jdk9/dev/jaxp
+                ./hotspot:   pulling from http://hg.openjdk.java.net/jdk9/dev/hotspot
+                   ./jaxp:   searching for changes
+                   ./jaxp:   no changes found
+                ./hotspot:   searching for changes
+                ./hotspot:   no changes found
+    Waiting 5 secs before spawning next background command.
 
 ::: {.NavBit}
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)

--- a/src/hgHelp.md
+++ b/src/hgHelp.md
@@ -4,90 +4,90 @@
 [« Previous](repositories.html#verify) • [TOC](index.html) • [Next »](repositories.html#cloneSandbox)
 :::
 
->     $ hg help
->     Mercurial Distributed SCM
->
->     list of commands:
->
->      add           add the specified files on the next commit
->      addremove     add all new files, delete all missing files
->      annotate      show changeset information by line for each file
->      archive       create an unversioned archive of a repository revision
->      backout       reverse effect of earlier changeset
->      bisect        subdivision search of changesets
->      bookmarks     track a line of development with movable markers
->      branch        set or show the current branch name
->      branches      list repository named branches
->      bundle        create a changegroup file
->      cat           output the current or given revision of files
->      clone         make a copy of an existing repository
->      commit        commit the specified files or all outstanding changes
->      copy          mark files as copied for the next commit
->      diff          diff repository (or selected files)
->      export        dump the header and diffs for one or more changesets
->      forget        forget the specified files on the next commit
->      graft         copy changes from other branches onto the current branch
->      grep          search for a pattern in specified files and revisions
->      heads         show branch heads
->      help          show help for a given topic or a help overview
->      identify      identify the working copy or specified revision
->      import        import an ordered set of patches
->      incoming      show new changesets found in source
->      init          create a new repository in the given directory
->      locate        locate files matching specific patterns
->      log           show revision history of entire repository or files
->      manifest      output the current or given revision of the project manifest
->      merge         merge working directory with another revision
->      outgoing      show changesets not found in the destination
->      parents       show the parents of the working directory or revision
->      paths         show aliases for remote repositories
->      phase         set or show the current phase name
->      pull          pull changes from the specified source
->      push          push changes to the specified destination
->      recover       roll back an interrupted transaction
->      remove        remove the specified files on the next commit
->      rename        rename files; equivalent of copy + remove
->      resolve       redo merges or set/view the merge status of files
->      revert        restore files to their checkout state
->      root          print the root (top) of the current working directory
->      serve         start stand-alone webserver
->      showconfig    show combined config settings from all hgrc files
->      status        show changed files in the working directory
->      summary       summarize working directory state
->      tag           add one or more tags for the current or given revision
->      tags          list repository tags
->      unbundle      apply one or more changegroup files
->      update        update working directory (or switch revisions)
->      verify        verify the integrity of the repository
->      version       output version and copyright information
->
->     enabled extensions:
->
->      jcheck        (no help text available)
->      trees         manage loosely-coupled nested repositories
->
->     additional help topics:
->
->      config        Configuration Files
->      dates         Date Formats
->      diffs         Diff Formats
->      environment   Environment Variables
->      extensions    Using Additional Features
->      filesets      Specifying File Sets
->      glossary      Glossary
->      hgignore      Syntax for Mercurial Ignore Files
->      hgweb         Configuring hgweb
->      merge-tools   Merge Tools
->      multirevs     Specifying Multiple Revisions
->      patterns      File Name Patterns
->      phases        Working with Phases
->      revisions     Specifying Single Revisions
->      revsets       Specifying Revision Sets
->      subrepos      Subrepositories
->      templating    Template Usage
->      urls          URL Paths
->
->     use "hg -v help" to show builtin aliases and global options
+    $ hg help
+    Mercurial Distributed SCM
+
+    list of commands:
+
+     add           add the specified files on the next commit
+     addremove     add all new files, delete all missing files
+     annotate      show changeset information by line for each file
+     archive       create an unversioned archive of a repository revision
+     backout       reverse effect of earlier changeset
+     bisect        subdivision search of changesets
+     bookmarks     track a line of development with movable markers
+     branch        set or show the current branch name
+     branches      list repository named branches
+     bundle        create a changegroup file
+     cat           output the current or given revision of files
+     clone         make a copy of an existing repository
+     commit        commit the specified files or all outstanding changes
+     copy          mark files as copied for the next commit
+     diff          diff repository (or selected files)
+     export        dump the header and diffs for one or more changesets
+     forget        forget the specified files on the next commit
+     graft         copy changes from other branches onto the current branch
+     grep          search for a pattern in specified files and revisions
+     heads         show branch heads
+     help          show help for a given topic or a help overview
+     identify      identify the working copy or specified revision
+     import        import an ordered set of patches
+     incoming      show new changesets found in source
+     init          create a new repository in the given directory
+     locate        locate files matching specific patterns
+     log           show revision history of entire repository or files
+     manifest      output the current or given revision of the project manifest
+     merge         merge working directory with another revision
+     outgoing      show changesets not found in the destination
+     parents       show the parents of the working directory or revision
+     paths         show aliases for remote repositories
+     phase         set or show the current phase name
+     pull          pull changes from the specified source
+     push          push changes to the specified destination
+     recover       roll back an interrupted transaction
+     remove        remove the specified files on the next commit
+     rename        rename files; equivalent of copy + remove
+     resolve       redo merges or set/view the merge status of files
+     revert        restore files to their checkout state
+     root          print the root (top) of the current working directory
+     serve         start stand-alone webserver
+     showconfig    show combined config settings from all hgrc files
+     status        show changed files in the working directory
+     summary       summarize working directory state
+     tag           add one or more tags for the current or given revision
+     tags          list repository tags
+     unbundle      apply one or more changegroup files
+     update        update working directory (or switch revisions)
+     verify        verify the integrity of the repository
+     version       output version and copyright information
+
+    enabled extensions:
+
+     jcheck        (no help text available)
+     trees         manage loosely-coupled nested repositories
+
+    additional help topics:
+
+     config        Configuration Files
+     dates         Date Formats
+     diffs         Diff Formats
+     environment   Environment Variables
+     extensions    Using Additional Features
+     filesets      Specifying File Sets
+     glossary      Glossary
+     hgignore      Syntax for Mercurial Ignore Files
+     hgweb         Configuring hgweb
+     merge-tools   Merge Tools
+     multirevs     Specifying Multiple Revisions
+     patterns      File Name Patterns
+     phases        Working with Phases
+     revisions     Specifying Single Revisions
+     revsets       Specifying Revision Sets
+     subrepos      Subrepositories
+     templating    Template Usage
+     urls          URL Paths
+
+    use "hg -v help" to show builtin aliases and global options
 
 ::: {.NavBit}
 [« Previous](repositories.html#verify) • [TOC](index.html) • [Next »](repositories.html#cloneSandbox)

--- a/src/producingChangeset.md
+++ b/src/producingChangeset.md
@@ -46,19 +46,19 @@ the individual cloned repositories of the forest, the `hg
 status` command may be used to see the changes in a single
 repository.
 
->     $ hg root
->     /u/iris/sandbox/box
->     $ hg status
->     ? duke/images/DukeTubbingSmall.png
->     $ hg add duke/images/DukeTubbingSmall.png
->     $ hg status
->     A duke/images/DukeTubbingSmall.png
+    $ hg root
+    /u/iris/sandbox/box
+    $ hg status
+    ? duke/images/DukeTubbingSmall.png
+    $ hg add duke/images/DukeTubbingSmall.png
+    $ hg status
+    A duke/images/DukeTubbingSmall.png
 
 To see changes made to the repositories use _**`hg`**_ `status`:
 
->     $ hg status
->     [.]
->     A duke/images/DukeTubbingSmall.png
+    $ hg status
+    [.]
+    A duke/images/DukeTubbingSmall.png
 
 In this example, the repository was previously cloned as described in
 [Cloning a Sandbox Repository](repositories.html#cloneSandbox). A new file
@@ -68,10 +68,10 @@ In this example, the repository was previously cloned as described in
 
 A single change is described by a block of text of the following form:
 
->     <bugid>: <synopsis-of-symptom>
->     Summary: <summary-of-code-change>
->     Reviewed-by: <reviewer>+
->     Contributed-by: <contributor-email>
+    <bugid>: <synopsis-of-symptom>
+    Summary: <summary-of-code-change>
+    Reviewed-by: <reviewer>+
+    Contributed-by: <contributor-email>
 
 There may be more than one _bugid_ line, but there
 must be at least one.
@@ -96,10 +96,10 @@ There will be exceptions for merge changesets, tag changesets, etc.
 
 Example:
 
->     1234567: NPE thrown on FileInputStream("")
->     Summary: Rewrite precondition-checking code in io.c
->     Reviewed-by: mr
->     Contributed-by: Ben Bitdiddle <ben at bits.org>
+    1234567: NPE thrown on FileInputStream("")
+    Summary: Rewrite precondition-checking code in io.c
+    Reviewed-by: mr
+    Contributed-by: Ben Bitdiddle <ben at bits.org>
 
 If a changeset contains multiple unrelated changes (this is frowned upon, but
 may happen from time to time) then its comment will contain multiple blocks of
@@ -115,20 +115,20 @@ depending upon their goals.
 The following commands commit all of the changes in a repository to a
 changeset.
 
->     $ cat ../message
->     1111111: Missing Duke gif
->     Summary:  Add missing file
->     Reviewed-by: iag
->     $ hg commit -l ../message
->     $ hg toutgoing
->     [.]
->     comparing with http://hg.openjdk.java.net/sandbox/box
->     searching for changes
->     changeset:   23:fb12953f3a35
->     tag:         tip
->     user:        iris
->     date:        Wed Dec 12 21:05:59 2007 -0800
->     summary:     1111111: Missing Duke gif
+    $ cat ../message
+    1111111: Missing Duke gif
+    Summary:  Add missing file
+    Reviewed-by: iag
+    $ hg commit -l ../message
+    $ hg toutgoing
+    [.]
+    comparing with http://hg.openjdk.java.net/sandbox/box
+    searching for changes
+    changeset:   23:fb12953f3a35
+    tag:         tip
+    user:        iris
+    date:        Wed Dec 12 21:05:59 2007 -0800
+    summary:     1111111: Missing Duke gif
 
 ## Merging
 
@@ -148,11 +148,11 @@ Option 1: _**`hg`**_ `pull`
 > _**`hg`**_ `pull` all by itself. This option allows merging off-line or at a
 > later time.
 >
->>     $ hg pull
->>     [.]
->>     pulling from http://hg.openjdk.java.net/sandbox/box
->>     searching for changes
->>     no changes found
+>     $ hg pull
+>     [.]
+>     pulling from http://hg.openjdk.java.net/sandbox/box
+>     searching for changes
+>     no changes found
 >
 > In Mercurial, pulling changesets will not update or merge into the working set
 > of files. To update the clone, run _**`hg`**_ `update`. If the update
@@ -165,16 +165,16 @@ Option 2: _**`hg`**_ `fetch`
 > fetch extension is distributed with Mercurial but needs to be enabled. Edit
 > the `.hgrc` to include the following entries:
 >
->>     [extensions]
->>     fetch=
+>     [extensions]
+>     fetch=
 >
 > Once the fetch extension has been enabled, _**`hg`**_ `fetch` may be invoked as follows:
 >
->>     $ hg fetch
->>     [.]
->>     pulling from http://hg.openjdk.java.net/sandbox/box
->>     searching for changes
->>     no changes found
+>     $ hg fetch
+>     [.]
+>     pulling from http://hg.openjdk.java.net/sandbox/box
+>     searching for changes
+>     no changes found
 
 > ---
 > Actual file merging will be done with the selected Mercurial merging tool see
@@ -200,27 +200,27 @@ this is **strongly** discouraged. Empty or
 insecure passphrases may be reset using `ssh-keygen
 -p`; this does not change the keys.
 
->     $ ssh-keygen -t rsa -b 4096
->     Enter file in which to save the key(/u/iris/.ssh/id_rsa):
->     Generating public/private rsa key pair.
->     Enter passphrase(empty for no passphrase):
->     Enter same passphrase again:
->     Your identification has been saved in /u/iris/.ssh/id_rsa.
->     Your public key has been saved in /u/iris/.ssh/id_rsa.pub.
->     The key fingerprint is:
->     md5 4096 c2:b7:00:e6:4b:da:ea:ec:32:30:f5:bd:12:26:04:83 iris@duke
->     The key's randomart image is:
->     +--[ RSA 4096]----+
->     |    E.=          |
->     |     . *         |
->     |      o .   .    |
->     |         + o     |
->     |        S + .    |
->     |       .   + .   |
->     |        + + +..  |
->     |       * . oo+.  |
->     |      o . .o..   |
->     +-----------------+
+    $ ssh-keygen -t rsa -b 4096
+    Enter file in which to save the key(/u/iris/.ssh/id_rsa):
+    Generating public/private rsa key pair.
+    Enter passphrase(empty for no passphrase):
+    Enter same passphrase again:
+    Your identification has been saved in /u/iris/.ssh/id_rsa.
+    Your public key has been saved in /u/iris/.ssh/id_rsa.pub.
+    The key fingerprint is:
+    md5 4096 c2:b7:00:e6:4b:da:ea:ec:32:30:f5:bd:12:26:04:83 iris@duke
+    The key's randomart image is:
+    +--[ RSA 4096]----+
+    |    E.=          |
+    |     . *         |
+    |      o .   .    |
+    |         + o     |
+    |        S + .    |
+    |       .   + .   |
+    |        + + +..  |
+    |       * . oo+.  |
+    |      o . .o..   |
+    +-----------------+
 
 The `~/.ssh/id_rsa.pub` is a text file
 containing the public ssh key. This file should be mailed as an attachment
@@ -234,8 +234,8 @@ completion. This process may take a couple of days.
 > `~/.ssh/config` file to connect to the OpenJDK
 > Mercurial server:
 > 
->>     Host *.openjdk.java.net
->>     ProxyCommand /usr/lib/ssh/ssh-socks5-proxy-connect -h [socks_proxy_address] %h %p
+>     Host *.openjdk.java.net
+>     ProxyCommand /usr/lib/ssh/ssh-socks5-proxy-connect -h [socks_proxy_address] %h %p
 >
 > See the `ssh-socks5-proxy-connect` man page and
 > `ssh-config` man page for more information. Other
@@ -260,23 +260,23 @@ ssh-related operations.
   To avoid having to constantly type in the passphrase, use the ssh-agent on your
   local client to cache your pashphrase:
 
-  >     $ eval `ssh-agent`
-  >     Agent pid 17450
-  >     $ ssh-add
-  >     Enter passphrase for /u/iris/.ssh/id_rsa:
-  >     Identity added: /u/iris/.ssh/id_rsa(/u/iris/.ssh/id_rsa)
+      $ eval `ssh-agent`
+      Agent pid 17450
+      $ ssh-add
+      Enter passphrase for /u/iris/.ssh/id_rsa:
+      Identity added: /u/iris/.ssh/id_rsa(/u/iris/.ssh/id_rsa)
 
   The same ssh-agent process can be shared with multiple shells. There are
   various ways to do this. Bash users can accomplish this with the following code
   in `.bashrc`:
 
-  >     if [ "$PS1" -a -d $HOME/.ssh ]; then
-  >       if [ "x$SSH_AUTH_SOCK" = x ]; then
-  >         eval `ssh-agent | grep -v 'echo Agent pid'`
-  >         ssh-add
-  >         trap "echo Killing SSH agent $SSH_AGENT_PID; kill $SSH_AGENT_PID" 0
-  >       fi
-  >     fi
+      if [ "$PS1" -a -d $HOME/.ssh ]; then
+        if [ "x$SSH_AUTH_SOCK" = x ]; then
+          eval `ssh-agent | grep -v 'echo Agent pid'`
+          ssh-add
+          trap "echo Killing SSH agent $SSH_AGENT_PID; kill $SSH_AGENT_PID" 0
+        fi
+      fi
 
   For secure operation, only start an ssh-agent when needed and kill it off when
   the shell completes. Test this by running `ssh 'hostname' echo
@@ -287,8 +287,8 @@ ssh-related operations.
   To avoid needing to constantly type in the password, add the public key to the
   list of ssh authorized keys.
 
-  >     $ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-  >     $ chmod 600 ~/.ssh/authorized_keys
+      $ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+      $ chmod 600 ~/.ssh/authorized_keys
 
 #### Setting the `default-push` Path to the Server Repositories
 
@@ -310,35 +310,35 @@ path in every repository's `.hg/hgrc` file. The
 private to the repository. The following example defines the "default" and
 "default-push" paths for clones of the jdk9/dev team repository.
 
->     [paths]
->     default = http://hg.openjdk.java.net/jdk9/dev
->     default-push = ssh://<JDK_username>@hg.openjdk.java.net/jdk9/dev
+    [paths]
+    default = http://hg.openjdk.java.net/jdk9/dev
+    default-push = ssh://<JDK_username>@hg.openjdk.java.net/jdk9/dev
 
 Given a `JDK_username` this simple script will
 attempt to do this for all the repositories:
 
->     #!/bin/sh
->     username=$1
->     hgdirs="`find . -type d -name .hg`"
->     for i in ${hgdirs}; do
->       d="`dirname ${i}`"
->       defpush="`(cd ${d} && hg paths default-push 2> /dev/null)`"
->       if [ "${defpush}" = "" ] ; then
->         defpath="`(cd ${d} && hg paths default 2> /dev/null)`"
->         if [ "${defpath}" != "" ] ; then
->           defpush="`echo ${defpath} | sed -e 's@http://\([^/]*/[^/]*/[^/]*\)/\(.*\)@ssh://$username\@\1/\2@'`"
->           cp ${i}/hgrc ${i}/hgrc.orig
->           echo "default-push = ${defpush}" >> ${i}/hgrc
->           echo "Added default-push: ${defpush}"
->         fi
->       fi
->     done
->     for i in ${hgdirs}; do
->       d="`dirname ${i}`"
->       echo "(cd ${d} && hg paths)"
->       (cd ${d} && hg paths)
->     done
->     exit 0
+    #!/bin/sh
+    username=$1
+    hgdirs="`find . -type d -name .hg`"
+    for i in ${hgdirs}; do
+      d="`dirname ${i}`"
+      defpush="`(cd ${d} && hg paths default-push 2> /dev/null)`"
+      if [ "${defpush}" = "" ] ; then
+        defpath="`(cd ${d} && hg paths default 2> /dev/null)`"
+        if [ "${defpath}" != "" ] ; then
+          defpush="`echo ${defpath} | sed -e 's@http://\([^/]*/[^/]*/[^/]*\)/\(.*\)@ssh://$username\@\1/\2@'`"
+          cp ${i}/hgrc ${i}/hgrc.orig
+          echo "default-push = ${defpush}" >> ${i}/hgrc
+          echo "Added default-push: ${defpush}"
+        fi
+      fi
+    done
+    for i in ${hgdirs}; do
+      d="`dirname ${i}`"
+      echo "(cd ${d} && hg paths)"
+      (cd ${d} && hg paths)
+    done
+    exit 0
 
 <!--
 #. Option 2: Use the <code>defpath</code> ExtensionAnother way to setup the default-push path is to use the Mercurial defpath
@@ -372,7 +372,7 @@ repositories. However, it is important that before any changesets are pushed,
 the corresponding forest pull and merge with the destination forest be
 performed; otherwise there is a risk of breaking the build.
 
->     $ hg push
+    $ hg push
 
 After the push has been accepted, an automatic e-mail notification will be sent
 to the [mailing list](http://mail.openjdk.java.net) associated with the

--- a/src/repositories.md
+++ b/src/repositories.md
@@ -115,8 +115,8 @@ used to apply commands to all the repositories in the
 
 Create and edit the `~/.hgrc` file to minimally contain the following entry:
 
->     [ui]
->     username = <openjdk_username>
+    [ui]
+    username = <openjdk_username>
 
 _openjdk\_username_ is a plain lowercase, alphanumeric
 token (not an e-mail address) with twelve characters or less. The first
@@ -145,23 +145,23 @@ the following steps.
 
 #. Verify that Mercurial is version 2.6.3 (or newer).
 
-   >     $ hg version
-   >     Mercurial Distributed SCM (version 2.9)
-   >     (see http://mercurial.selenic.com for more information)
-   >
-   >     Copyright (C) 2005-2014 Matt Mackall and others
-   >     This is free software; see the source for copying conditions. There is NO
-   >     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+       $ hg version
+       Mercurial Distributed SCM (version 2.9)
+       (see http://mercurial.selenic.com for more information)
+   
+       Copyright (C) 2005-2014 Matt Mackall and others
+       This is free software; see the source for copying conditions. There is NO
+       warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #. Verify that the list of enabled extensions includes fetch and mq.
 
-   >     $ hg help
-   > [full output](hgHelp.html)
+       $ hg help
+   [full output](hgHelp.html)
 
 #. Verify that the `~/.hgrc` configuration looks correct. Minimally it should contain the following entries:
 
-   >     $ hg showconfig
-   >     ui.username=iris
+       $ hg showconfig
+       ui.username=iris
 
 At this point, it should be possible to start retrieving source from the
 repositories.
@@ -179,17 +179,17 @@ may be used to run test commands against Mercurial without fear of causing
 damage to development source. Use them freely but with discretion; content in
 them may be deleted at any time.
 
->     $ mkdir sandbox; cd sandbox
->     $ hg clone http://hg.openjdk.java.net/sandbox/box
->     destination directory: box
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 23 changesets with 24 changes to 5 files
->     4 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     $ du -s box
->     46      box
+    $ mkdir sandbox; cd sandbox
+    $ hg clone http://hg.openjdk.java.net/sandbox/box
+    destination directory: box
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 23 changesets with 24 changes to 5 files
+    4 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    $ du -s box
+    46      box
 
 #### ... a Forest {#cloneForest}
 
@@ -203,38 +203,38 @@ into the directory `9dev`.
 [trees](http://openjdk.java.net/projects/code-tools/trees/)
 extension just use `tclone`:
 
-   >     $ hg tclone http://hg.openjdk.java.net/jdk9/dev 9dev
-   > [full output](tClone.html)
+       $ hg tclone http://hg.openjdk.java.net/jdk9/dev 9dev
+   [full output](tClone.html)
 
 #. To clone the forest using `get_source.sh`, first
 clone the main tree:
 
-   >     $ hg clone http://hg.openjdk.java.net/jdk9/dev 9dev
-   >     requesting all changes
-   >     adding changesets
-   >     adding manifests
-   >     adding file changes
-   >     added 997 changesets with 1477 changes to 138 files
-   >     updating to branch default
-   >     82 files updated, 0 files merged, 0 files removed, 0 files unresolved
+       $ hg clone http://hg.openjdk.java.net/jdk9/dev 9dev
+       requesting all changes
+       adding changesets
+       adding manifests
+       adding file changes
+       added 997 changesets with 1477 changes to 138 files
+       updating to branch default
+       82 files updated, 0 files merged, 0 files removed, 0 files unresolved
 
    Then clone the repositories in the forest:
 
-   >     $ cd 9dev
-   >     $ sh ./get_source.sh
-   > [full output](getSource.html)
+       $ cd 9dev
+       $ sh ./get_source.sh
+   [full output](getSource.html)
 
 Regardless of how the forest was cloned, this is the resulting populated
 forest.
 
->     $ du -s
->     934532  .
->     $ ls
->     ASSEMBLY_EXCEPTION  hotspot    LICENSE   README-builds.html
->     common              jaxp       make      test
->     configure           jaxws      Makefile  THIRD_PARTY_README
->     corba               jdk        nashorn
->     get_source.sh       langtools  README
+    $ du -s
+    934532  .
+    $ ls
+    ASSEMBLY_EXCEPTION  hotspot    LICENSE   README-builds.html
+    common              jaxp       make      test
+    configure           jaxws      Makefile  THIRD_PARTY_README
+    corba               jdk        nashorn
+    get_source.sh       langtools  README
 
 #### ... a Single Repository {#cloneSingle}
 
@@ -245,17 +245,17 @@ example shows how to clone the `langtools`
 repository from _jdk9/dev_ into the default
 destination directory.
 
->     $ hg clone http://hg.openjdk.java.net/jdk9/dev/langtools
->     destination directory: langtools
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 2289 changesets with 21194 changes to 7004 files
->     updating to branch default
->     6212 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     $ du -s langtools
->     84396   langtools
+    $ hg clone http://hg.openjdk.java.net/jdk9/dev/langtools
+    destination directory: langtools
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 2289 changesets with 21194 changes to 7004 files
+    updating to branch default
+    6212 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    $ du -s langtools
+    84396   langtools
 
 ::: {.NavBit}
 [« Previous](processWorkflow.html) • [TOC](index.html) • [Next »](mailingLists.html)

--- a/src/tClone.md
+++ b/src/tClone.md
@@ -4,87 +4,87 @@
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)
 :::
 
->     $ hg tclone http://hg.openjdk.java.net/jdk9/dev 9dev
->     $ hg tclone http://hg.openjdk.java.net/jdk9/dev 9dev
->     cloning http://hg.openjdk.java.net/jdk9/dev
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 997 changesets with 1477 changes to 138 files
->     updating to branch default
->     82 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/corba
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 567 changesets with 3577 changes to 1398 files
->     updating to branch default
->     1195 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/corba
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/hotspot
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 6126 changesets with 36489 changes to 5247 files
->     updating to branch default
->     4357 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/hotspot
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/jaxp
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 570 changesets with 6285 changes to 4230 files
->     updating to branch default
->     2078 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/jaxp
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/jaxws
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 471 changesets with 15683 changes to 6727 files
->     updating to branch default
->     3710 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/jaxws
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/jdk
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 9507 changesets with 91840 changes to 26823 files
->     updating to branch default
->     22251 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/jdk
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/langtools
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 2326 changesets with 21344 changes to 7022 files
->     updating to branch default
->     6196 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/langtools
->
->     cloning http://hg.openjdk.java.net/jdk9/dev/nashorn
->     requesting all changes
->     adding changesets
->     adding manifests
->     adding file changes
->     added 766 changesets with 6302 changes to 2248 files
->     updating to branch default
->     2121 files updated, 0 files merged, 0 files removed, 0 files unresolved
->     created /home/iris/9dev/nashorn
+    $ hg tclone http://hg.openjdk.java.net/jdk9/dev 9dev
+    $ hg tclone http://hg.openjdk.java.net/jdk9/dev 9dev
+    cloning http://hg.openjdk.java.net/jdk9/dev
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 997 changesets with 1477 changes to 138 files
+    updating to branch default
+    82 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/corba
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 567 changesets with 3577 changes to 1398 files
+    updating to branch default
+    1195 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/corba
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/hotspot
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 6126 changesets with 36489 changes to 5247 files
+    updating to branch default
+    4357 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/hotspot
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/jaxp
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 570 changesets with 6285 changes to 4230 files
+    updating to branch default
+    2078 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/jaxp
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/jaxws
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 471 changesets with 15683 changes to 6727 files
+    updating to branch default
+    3710 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/jaxws
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/jdk
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 9507 changesets with 91840 changes to 26823 files
+    updating to branch default
+    22251 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/jdk
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/langtools
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 2326 changesets with 21344 changes to 7022 files
+    updating to branch default
+    6196 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/langtools
+
+    cloning http://hg.openjdk.java.net/jdk9/dev/nashorn
+    requesting all changes
+    adding changesets
+    adding manifests
+    adding file changes
+    added 766 changesets with 6302 changes to 2248 files
+    updating to branch default
+    2121 files updated, 0 files merged, 0 files removed, 0 files unresolved
+    created /home/iris/9dev/nashorn
 
 ::: {.NavBit}
 [« Previous](repositories.html#cloneForest) • [TOC](index.html) • [Next »](repositories.html#cloneSingle)


### PR DESCRIPTION
Blockquotes were used to format code blocks. With proper styling for `<pre><code>` blocks this is no longer needed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * Jesper Wilhelmsson ([jwilhelm](@JesperIRL) - **Reviewer**) ⚠️ Review applies to 0827c3e6030e4e1c63eb73a78a724bf2d7ce2597


### Download
`$ git fetch https://git.openjdk.java.net/guide pull/24/head:pull/24`
`$ git checkout pull/24`
