### PR TITLE
Added pandoc version recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the dedicated [guide-dev mail list](https://mail.openjdk.java.net/mailman/listin
 ## Building the Developers' Guide
 
 The project comes with a `Makefile`. Simply type `make` to generate HTML files from the source
-Markdown. The build requires the tools `pandoc`, `iconv`, and `perl` and assumes a POSIX environment.
+Markdown. The build requires the tools `pandoc`, `iconv`, and `perl` and assumes a POSIX environment. We recommend using at least pandoc 2.0.
 The resulting HTML files in the `build` directory are exactly the files published on the
 [OpenJDK web server](https://openjdk.java.net/guide/). There is, however, a larger framework
 on the web server with fonts and CSS


### PR DESCRIPTION
It was noted that pandoc 1.12.3.1 did not support all the flags we use in the build. V2.0 has all flags we use so I added a recommendation to use at least that version.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/guide pull/27/head:pull/27`
`$ git checkout pull/27`
