### PR TITLE
Fix jcheck whitespace checks so they make sense for the Guide

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -33,7 +33,7 @@ version=0
 domain=openjdk.org
 
 [checks "whitespace"]
-files=.*\.java$|.*\.c$|.*\.h$|.*\.cpp$|.*\.hpp$
+files=.*\.md$|.*\.html$|.*\.css$|Makefile
 
 [checks "reviewers"]
 reviewers=1


### PR DESCRIPTION
The whitespace file filter in .jcheck/conf had just been copied from a java-based project...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.java.net/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/guide pull/48/head:pull/48`
`$ git checkout pull/48`
