### PR TITLE
jcheck should allow tabs in Makefile

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -34,6 +34,7 @@ domain=openjdk.org
 
 [checks "whitespace"]
 files=.*\.md$|.*\.html$|.*\.css$|Makefile
+ignore-tabs=Makefile
 
 [checks "reviewers"]
 reviewers=1


### PR DESCRIPTION
As the title says. I forgot to add the exception to jcheck to allow leading tabs in Makefiles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.java.net/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/guide pull/51/head:pull/51`
`$ git checkout pull/51`

To update a local copy of the PR:
`$ git checkout pull/51`
`$ git pull https://git.openjdk.java.net/guide pull/51/head`
