### PR TITLE
Updated directory mapping for JDK 16

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1685,9 +1685,9 @@ This list is intended to make it easier to identify which email list to include 
   * Many files in the awt directories are shared between 2D and AWT
     * See [https://openjdk.java.net/groups/2d/2dawtfiles.html](https://openjdk.java.net/groups/2d/2dawtfiles.html)
     * And see [https://openjdk.java.net/groups/2d](https://openjdk.java.net/groups/2d)
-  * `color`, `font`, `freetype`, `geom`, `imageio`, `java2d`, `jpeg`, `lcms`, `mlib`, `print`, Graphics primitives – 2D
+  * `color`, `font`, `freetype`, `geom`, `imageio`, `java2d`, `jpeg`, `lcms`, `mlib`, `print`, graphics primitives – 2D
   * `splashscreen`, `dnd`, `eawt`, `lwawt` – AWT
-  * `im`, InputMethods – I18n, AWT
+  * `im`, input methods – I18n, AWT
   * `libjsound`, `sound` – Sound
   * `accessibility`, `laf` – Swing
 * `java.instrument` – Serviceability
@@ -1723,7 +1723,8 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.httpserver` – Net
 * `jdk.incubator.foreign` – LangTools
 * `jdk.incubator.httpclient` – Net
-* `jdk.incubator.jpackage` –
+* `jdk.incubator.jpackage` – Client
+* `jdk.incubator.vector` – HotSpot Compiler
 * `jdk.internal.ed` – LangTools
 * `jdk.internal.jvmstat` – Serviceability
 * `jdk.internal.le` – LangTools
@@ -1740,6 +1741,7 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.jdwp.agent` – Serviceability
 * `jdk.jfr` – JFR
 * `jdk.jlink` – LangTools
+* `jdk.jpackage` – Client
 * `jdk.jshell` – LangTools
 * `jdk.jsobject` – LangTools
 * `jdk.jstatd` – Serviceability


### PR DESCRIPTION
A couple of new directories has been added in JDK 16.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/guide pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/guide pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/guide/pull/54.diff">https://git.openjdk.java.net/guide/pull/54.diff</a>

</details>
