### PR TITLE
Correct the build/test link to use the actual official links

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1052,7 +1052,7 @@ _Congratulations!_ Your changeset will now make its way towards a promoted build
 ::: {.box}
 [Quick Links]{.boxheader}
 
-* [Official build instructions (source code)](https://git.openjdk.java.net/jdk/blob/master/doc/building.md)
+* [Official build instructions](https://openjdk.java.net/groups/build/doc/building.html)
 * [openjdk/jdk GitHub project](https://github.com/openjdk/jdk)
 * [JDK 16 General-Availability Release](https://jdk.java.net/16/)
 :::
@@ -1124,7 +1124,7 @@ There are many other targets available as well. Use `make help` to find out more
 ::: {.box}
 [Quick Links]{.boxheader}
 
-* [Using the run-test Framework](https://github.com/openjdk/jdk/blob/master/doc/testing.md)
+* [Using the run-test Framework](https://openjdk.java.net/groups/build/doc/testing.html)
 * [JTReg Harness Documentation](https://openjdk.java.net/jtreg/)
 * [Google Test Documentation](https://github.com/google/googletest/blob/master/googletest/docs/primer.md)
 :::


### PR DESCRIPTION
It was recently pointed out (in the discussion of JDK-8273497) that the Guide does not use the official link to build instructions, despite claiming so. Correct this. Also use official link for testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/guide pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/guide pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/guide/pull/64.diff">https://git.openjdk.java.net/guide/pull/64.diff</a>

</details>
