### PR TITLE
Remove empty files

### DIFF
--- a/src/about.md
+++ b/src/about.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/bugDatabase.md
+++ b/src/bugDatabase.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/changePlanning.md
+++ b/src/changePlanning.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/codeConventions.md
+++ b/src/codeConventions.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/codeowners.md
+++ b/src/codeowners.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/faq.md
+++ b/src/faq.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/intro.md
+++ b/src/intro.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/mailingLists.md
+++ b/src/mailingLists.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/next.md
+++ b/src/next.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/processWorkflow.md
+++ b/src/processWorkflow.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/producingChangeset.md
+++ b/src/producingChangeset.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/repositories.md
+++ b/src/repositories.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)

--- a/src/testingChanges.md
+++ b/src/testingChanges.md
@@ -1,3 +1,0 @@
-% Page moved
-
-The OpenJDK Developers' Guide has been merged into a single document. Please update your links to point to the new location: [OpenJDK Developers' Guide](index.html)


### PR DESCRIPTION
The guide was merged into one file a year ago and since then all the old files has been in place with a forward link to the new single file. I think a year is long enough. This change removes all those forward files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/guide pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/guide pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/guide/pull/68.diff">https://git.openjdk.java.net/guide/pull/68.diff</a>

</details>
