### PR TITLE
Updated fix version

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -272,7 +272,7 @@ Here's how to fix that:
 ~~~
 Fix was pushed while main bug was targeted to 'N+1'. Reset the main bug to fixed in 'N', reset this bug to fix in 'N+1' and closed as 'Not An Issue' since JDK N+1 will automatically get this fix from JDK N.
 ~~~
-   * Change the 'Fix Version/s' from 'N' to 'N+1'.
+   * Change the 'Fix Version/s' from 'N' to 'na'.
    * Close the _backport_ bug as "Not an Issue".
 #. Clean up the _main_ bug
    * Copy the push notification comment from the _backport_ bug to the _main_ bug, e.g.:


### PR DESCRIPTION
Setting the fix version to 'N+1' results in having two backport records with the same fix version once the change is forwardported to mainline. This is a problem as JBS only show the oldest backport to each version in the list of backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/guide pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.java.net/guide pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/guide/pull/76.diff">https://git.openjdk.java.net/guide/pull/76.diff</a>

</details>
