### PR TITLE
update code-owners

### DIFF
--- a/src/guide/code-owners.md
+++ b/src/guide/code-owners.md
@@ -6,13 +6,9 @@ This list is intended to make it easier to identify which email list to include 
 
 * Build: [`build-dev@openjdk.java.net`](mailto:build-dev@openjdk.java.net)
 * Client
-  * AWT: [`awt-dev@openjdk.java.net`](mailto:awt-dev@openjdk.java.net)
-  * Beans: [`beans-dev@openjdk.java.net`](mailto:beans-dev@openjdk.java.net)
-  * Java 2D: [`2d-dev@openjdk.java.net`](mailto:2d-dev@openjdk.java.net)
+  * Client Libs: [`client-libs-dev@openjdk.java.net`](mailto:client-libs-dev@openjdk.java.net)
   * Java FX: [`openjfx-dev@openjdk.java.net`](mailto:openjfx-dev@openjdk.java.net)
   * jpackage: [`core-libs-dev@openjdk.java.net`](mailto:core-libs-dev@openjdk.java.net)
-  * Sound: [`sound-dev@openjdk.java.net`](mailto:sound-dev@openjdk.java.net)
-  * Swing: [`swing-dev@openjdk.java.net`](mailto:swing-dev@openjdk.java.net)
 * Core Libs: [`core-libs-dev@openjdk.java.net`](mailto:core-libs-dev@openjdk.java.net)
   * Net: [`net-dev@openjdk.java.net`](mailto:net-dev@openjdk.java.net)
   * NIO: [`nio-dev@openjdk.java.net`](mailto:nio-dev@openjdk.java.net)
@@ -109,16 +105,8 @@ This list is intended to make it easier to identify which email list to include 
     * `libverify` – LangTools
     * `libzip` – Core Libs
 * `java.compiler` – LangTools
-* `java.datatransfer` – AWT
-* `java.desktop` – Client
-  * Many files in the awt directories are shared between 2D and AWT
-    * See [https://openjdk.java.net/groups/2d/2dawtfiles.html](https://openjdk.java.net/groups/2d/2dawtfiles.html)
-    * And see [https://openjdk.java.net/groups/2d](https://openjdk.java.net/groups/2d)
-  * `color`, `font`, `freetype`, `geom`, `imageio`, `java2d`, `jpeg`, `lcms`, `mlib`, `print`, graphics primitives – 2D
-  * `splashscreen`, `dnd`, `eawt`, `lwawt` – AWT
-  * `im`, input methods – I18n, AWT
-  * `libjsound`, `sound` – Sound
-  * `accessibility`, `laf` – Swing
+* `java.datatransfer` – Client Libs
+* `java.desktop` – Client Libs
 * `java.instrument` – Serviceability
 * `java.logging` – Core Libs
 * `java.management` – Serviceability
@@ -137,7 +125,7 @@ This list is intended to make it easier to identify which email list to include 
 * `java.transaction.xa` – Core Libs
 * `java.xml` – Core Libs
 * `java.xml.crypto` – Security
-* `jdk.accessibility` – Swing
+* `jdk.accessibility` – Client Libs
 * `jdk.aot` – HotSpot Compiler
 * `jdk.attach` – Serviceability
 * `jdk.charsets` – I18n, Core Libs
@@ -152,7 +140,6 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.httpserver` – Net
 * `jdk.incubator.foreign` – LangTools
 * `jdk.incubator.httpclient` – Net
-* `jdk.incubator.jpackage` – Client
 * `jdk.incubator.vector` – HotSpot Compiler
 * `jdk.internal.ed` – LangTools
 * `jdk.internal.jvmstat` – Serviceability
@@ -170,7 +157,7 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.jdwp.agent` – Serviceability
 * `jdk.jfr` – JFR
 * `jdk.jlink` – LangTools
-* `jdk.jpackage` – Client
+* `jdk.jpackage` – Client / jpackage
 * `jdk.jshell` – LangTools
 * `jdk.jsobject` – LangTools
 * `jdk.jstatd` – Serviceability
@@ -190,7 +177,7 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.security.auth` – Security
 * `jdk.security.jgss` – Security
 * `jdk.unsupported` – Core Libs
-* `jdk.unsupported.desktop` – Swing
+* `jdk.unsupported.desktop` – Client Libs
 * `jdk.xml.dom` – Core Libs
 * `jdk.zipfs` – Core Libs
 * `sample` –


### PR DESCRIPTION
I just happened to notice the guide still has the old 5 retired client mailing lists instead of the client-libs-dev replacement

Then I noticed the code area assignments were out of date too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/guide pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.java.net/guide pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/guide/pull/84.diff">https://git.openjdk.java.net/guide/pull/84.diff</a>

</details>
