### PR TITLE
Cleaning up headers and examples

### DIFF
--- a/src/guide/about-this-guide.md
+++ b/src/guide/about-this-guide.md
@@ -2,4 +2,4 @@
 
 This guide is being maintained through the [OpenJDK Developers' Guide Project](https://openjdk.org/census#guide). The [source repository](https://github.com/openjdk/guide) is available at GitHub. The revision hash at the bottom of this page refers to the last published commit.
 
-Comments and questions may be sent to [guide-dev (at) openjdk.org](mailto:guide-dev-at-openjdk.org). Please let us know if there's anything in the guide that isn't clear.
+Comments and questions may be sent to [guide-dev@openjdk.org](mailto:guide-dev@openjdk.org). Please let us know if there's anything in the guide that isn't clear.

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -46,7 +46,7 @@ To find out which component to use for different bugs, consult the [directory to
 
 To resolve an issue as `Incomplete` is JBS lingo for "Need More Information". An issue that is `Resolved - Incomplete` is *not* closed but more information is needed to be able to work on it. If no more information is obtained within reasonable time the issue should be closed (`Closed - Incomplete`). Closing a resolved issue is done using the `Verify` option.
 
-## JBS Labels
+## JBS labels
 
 JBS labels are used to tag and group related issues. JBS labels are an open namespace, which means that anyone can create new labels at any time. In order to avoid confusion, however, it's best to reuse existing labels where possible. Most areas have their commonly used labels to identify issues in their respective area. Make an effort to find and use these labels. This can be done by editing the [Labels]{.jbs-field} field of a bug and entering the first few characters of the label you want to add. JIRA will pop up an autocomplete window with existing labels that match that prefix. Then choose one of the existing labels. Using the autocomplete window is preferable to typing the whole label name (even if you're a good typist) because it's easy for minor spelling errors to creep in, which can inadvertently introduce multiple labels with spurious spelling variations.
 
@@ -59,7 +59,7 @@ JBS labels should not be used to write documentation - don't try to write senten
 >
 > ---
 
-## JBS Label Dictionary
+## JBS label dictionary
 
 This table contains some frequently used JBS labels and their meaning. Please help keeping this dictionary up to date by adding your favorite labels. This table doesn’t dictate how to use labels, but rather document how they are used. That said, obviously it will help everyone if we try to follow a common standard and use similar labels in the same way across all entities that use JBS.
 
@@ -345,6 +345,9 @@ As with any issue the best way to deal with a [maintainer-pain]{.jbs-label} issu
     </td>
     <td class="dictionary">
       The [noreg-]{.jbs-label}`.*` and [nounit-]{.jbs-label}`.*` labels are used to explain why a bugfix doesn't need/have a regression test or a unit test. The suffix of the label is described below.
+
+      Please note that the [noreg-]{.jbs-label} namespace is closed, meaning that no new [noreg-]{.jbs-label} labels should be added unless properly
+      motivated, discussed, and agreed upon.
 
 [[-sqe]{.jbs-label}]{#noreg-sqe}
 :    Change can be verified by running an existing SQE test suite; the bug should identify the suite and the specific test case(s).

--- a/src/guide/mailing-lists.md
+++ b/src/guide/mailing-lists.md
@@ -23,7 +23,7 @@ There are a few different types of lists. The list name has two parts to explain
 > :    Technical discussions around the usage of the project artifacts.
 
 > `-discuss`
-> :    General discussions around the project. The special case `discuss@openjdk.org` is used for general discussions around OpenJDK. Discussions around new project proposals usually happens here.
+> :    General discussions around the project. The special case `discuss@openjdk.org` is used for general discussions around OpenJDK. Discussions around new project proposals usually happen here.
 
 >  `-changes`
 > :    Changeset notifications from the source code repositories maintained by the project.

--- a/src/guide/mailing-lists.md
+++ b/src/guide/mailing-lists.md
@@ -23,13 +23,13 @@ There are a few different types of lists. The list name has two parts to explain
 > :    Technical discussions around the usage of the project artifacts.
 
 > `-discuss`
-> :    General discussions around the project. The special case `discuss(at)openjdk.org` is used for general discussions around OpenJDK. Discussions around new project proposals usually happens here.
+> :    General discussions around the project. The special case `discuss@openjdk.org` is used for general discussions around OpenJDK. Discussions around new project proposals usually happens here.
 
 >  `-changes`
 > :    Changeset notifications from the source code repositories maintained by the project.
 
 > `-announce`
-> :    General project announcements. These lists are tightly moderated and are expected to be low traffic. The special case `announce(at)openjdk.org` is used for announcements for OpenJDK.
+> :    General project announcements. These lists are tightly moderated and are expected to be low traffic. The special case `announce@openjdk.org` is used for announcements for OpenJDK.
 
 > `-experts`
 > :    Expert group discussions. The list is restricted; only members of the expert group can subscribe.

--- a/src/guide/release-notes.md
+++ b/src/guide/release-notes.md
@@ -42,7 +42,7 @@ If you see an issue you feel should have a release note but you are not the assi
 
 For examples of well written release note issues in JBS, see [JDK-8276929](https://bugs.openjdk.org/browse/JDK-8276929) or [JDK-8278458](https://bugs.openjdk.org/browse/JDK-8278458).
 
-## General Conventions for Release Notes
+## General conventions for release notes
 
 The following are general practices that should be followed when creating release notes.
 
@@ -114,7 +114,7 @@ Unless labeled otherwise it will be assumed that the release note documents a ch
 [[~~RN-Change~~]{.jbs-label}]{#RN-Change}
 :   Deprecated.
 
-## Querying the Release Notes
+## Querying the release notes
 
 The Release Notes for a particular release can be found using the JBS query
 

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -30,43 +30,53 @@ In-depth documentation about the jtreg framework is found here: [jtreg harness](
 
 Below is a small example of a jtreg test. It’s a clean Java class with a main method that is called from the test harness. If the test fails we throw a RuntimeException. This is picked up by the harness and is reported as a test failure. Try to always write a meaningful message in the exception. One that actually helps with understanding what went wrong once the test fails.
 
-    /*
-     * @test
-     * @summary Make sure feature X handles Y correctly
-     * @run main TestXY
-     */
-    public class TestXY {
-        public static void main(String[] args) throws Exception {
-            var result = X.y();
-            if (result != expected_result) {
-                throw new RuntimeException("X.y() gave " + result + ", expected " + expected_result);
-            }
+~~~Java
+/*
+ * @test
+ * @summary Make sure feature X handles Y correctly
+ * @run main TestXY
+ */
+public class TestXY {
+    public static void main(String[] args) throws Exception {
+        var result = X.y();
+        if (result != expected_result) {
+            throw new RuntimeException("X.y() gave " + result + ", expected " + expected_result);
         }
     }
+}
+~~~
 
 This example only utilizes three jtreg specific tags, `@test`, `@summary`, and `@run`. `@test` simply tells jtreg that this class is a test, and `@summary` provides a description of the test. `@run` tells jtreg how to execute the test. In this case we simply tell jtreg to execute the main method of the class `TestXY`. `@run` isn't strictly necessary for jtreg to execute the test, an implicit `@run` tag will be added if none exists. However, for clarity and in order to avoid bugs it's recommended to always explicitly use the `@run` tag.
 
 There are several other tags that can be used in jtreg tests. You can for instance associate the test with a specific bug that this test is a regression test for.
 
-    @bug 7000001
+~~~
+@bug 7000001
+~~~
 
 Or you can specify a number of requirements that must be fulfilled for jtreg to execute the test.
 
-    @requires docker.support
-    @requires os.family != ”windows”
-    @requires os.maxMemory > 3G
-    @requires os.arch=="x86_64" | os.arch=="amd64"
+~~~
+@requires docker.support
+@requires os.family != ”windows”
+@requires os.maxMemory > 3G
+@requires os.arch=="x86_64" | os.arch=="amd64"
+~~~
 
 You can also specify if the test requires specific modules, and you can specify command line flags and run the test in several different ways.
 
-    @modules java.base/jdk.internal.misc
-    @run main/othervm -Xmx128m TestXY
+~~~
+@modules java.base/jdk.internal.misc
+@run main/othervm -Xmx128m TestXY
+~~~
 
 Note that you can have several `@run` tags in the same test with different command line options.
 
 jtreg also have support for labeling tests with keys using the `@key` tag. These keywords can then be used to filter the test selection. For instance if you have a UI test which needs to display a window you'll want to make sure the test harness doesn't try to run this test on a system which doesn't support headful tests. You do this by specifying
 
-    @key headful
+~~~
+@key headful
+~~~
 
 Another example is `@key randomness` that should be used to indicate that a test is using randomness - i.e. is intentionally non-deterministic.
 
@@ -80,48 +90,58 @@ The [compiler group](https://openjdk.org/groups/compiler/) has a section in thei
 
 When configuring the OpenJDK build you can tell it where your jtreg installation is located. When providing this information you can later run `make run-test` to execute jtreg tests.
 
-    sh ./configure --with-jtreg=/path/to/jtreg
-    make run-test TEST=tier1
+~~~
+sh ./configure --with-jtreg=/path/to/jtreg
+make run-test TEST=tier1
+~~~
 
 In the OpenJDK source tree you can find a directory called `test`. There are a large number of tests in this directory that are written to be used with jtreg.
 
-    make run-test TEST=test/jdk/java/lang/String/
+~~~
+make run-test TEST=test/jdk/java/lang/String/
+~~~
 
 You can also run jtreg without invoking make. In this case you’ll need to tell jtreg which JDK to test.
 
-    jtreg -jdk:/path/to/jdk /path/to/test
+~~~
+jtreg -jdk:/path/to/jdk /path/to/test
+~~~
 
 ## GTest
 
 As mentioned the Google test framework is mainly used for C++ unit tests. There are several of these in the `test/hotspot` directory. Currently, only the C++ code in the JVM area is supported by the OpenJDK GTest framework. The tests can be run without starting the JVM, which enables testing of JVM data structures that would be fragile to play with in a running JVM.
 
-    static int demo_comparator(int a, int b) {
-      if (a == b) {
-        return 0;
-      }
-      if (a < b) {
-        return -1;
-      }
-      return 1;
-    }
+~~~Java
+static int demo_comparator(int a, int b) {
+  if (a == b) {
+    return 0;
+  }
+  if (a < b) {
+    return -1;
+  }
+  return 1;
+}
 
-    TEST(Demo, quicksort) {
-      int test_array[] = {7,1,5,3,6,9,8,2,4,0};
-      int expected_array[] = {0,1,2,3,4,5,6,7,8,9};
+TEST(Demo, quicksort) {
+  int test_array[] = {7,1,5,3,6,9,8,2,4,0};
+  int expected_array[] = {0,1,2,3,4,5,6,7,8,9};
 
-      QuickSort::sort(test_array, 10, demo_comparator, false);
-      for (int i = 0; i < 10; i++) {
-        ASSERT_EQ(expected_array[i], test_array[i]);
-      }
-    }
+  QuickSort::sort(test_array, 10, demo_comparator, false);
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ(expected_array[i], test_array[i]);
+  }
+}
+~~~
 
 `ASSERT_EQ` is one example of an assertion that can be used in the test. Below are a few other examples. A full list is found in the [Google Test Documentation](https://github.com/google/googletest/blob/master/googletest/docs/primer.md).
 
-    ASSERT_TRUE(condition);
-    ASSERT_FALSE(condition);
-    EXPECT_EQ(expected, actual);
-    EXPECT_LT(val1, val2);
-    EXPECT_STREQ(expected_str, actual_str);
+~~~Java
+ASSERT_TRUE(condition);
+ASSERT_FALSE(condition);
+EXPECT_EQ(expected, actual);
+EXPECT_LT(val1, val2);
+EXPECT_STREQ(expected_str, actual_str);
+~~~
 
 `ASSERT` is a fatal assertion and will interrupt execution of the current sub-routine. `EXPECT` is a nonfatal assertion and will report the error but continues to run the test. All assertions have both an `ASSERT` and an `EXPECT` variant.
 
@@ -131,13 +151,17 @@ For more information on how to write good GTests in HotSpot, see [`doc/hotspot-u
 
 When configuring the OpenJDK build you can tell it where your GTest installation is located. Once configured, use make to run GTests.
 
-    sh ./configure --with-gtest=/path/to/gtest
-    make test TEST=gtest
+~~~
+sh ./configure --with-gtest=/path/to/gtest
+make test TEST=gtest
+~~~
 
 You can also use a regular expression to filter which tests to run:
 
-    make test TEST=gtest:code.*:os.*
-    make test TEST=gtest:$X/$variant
+~~~
+make test TEST=gtest:code.*:os.*
+make test TEST=gtest:$X/$variant
+~~~
 
 The second example above runs tests which match the regexp `$X.*` on a specific variant of the JVM. The variant is one of client, server, etc.
 
@@ -149,7 +173,9 @@ I'll say it right away so that it's not forgotten at the end: Remember to remove
 
 ### ProblemListing jtreg tests
 
-ProblemListing should be used for a short term exclusion while a test is being fixed, and for the exclusion of intermittently failing tests that cause too much noise, but can still be useful to run on an ad-hoc basis. ProblemListing is done in the file `ProblemList.txt`. There are actually several ProblemList files to choose from. Their location and name hint about what area or feature each file belongs to. Each file has sections for different components. All ProblemList files complement each other to build the total set of tests to exclude in jtreg runs.
+ProblemListing should be used for a short term exclusion while a test is being fixed, and for the exclusion of intermittently failing tests that cause too much noise, but can still be useful to run on an ad-hoc basis. ProblemListing is done in the file `ProblemList.txt`. For more details about the `ProblemList.txt` file see the [jtreg FAQ](https://openjdk.org/jtreg/faq.html#what-is-a-problemlist.txt-file).
+
+There are actually several ProblemList files to choose from in the JDK. Their location and name hint about what area or feature each file belongs to. Each file has sections for different components. All ProblemList files complement each other to build the total set of tests to exclude in jtreg runs.
 
 ~~~
 test/hotspot/jtreg/ProblemList.txt
@@ -251,9 +277,9 @@ The fix for the main issue should remove the test from the ProblemList or remove
 
 After a failure is handled by excluding a test, the main JBS issue should be re-triaged and possibly given a new priority. This should be handled by the standard triage process. A test exclusion results in an outage in our testing. This outage should be taken into consideration when triaging, in addition to the impact of the bug itself.
 
-## GitHub Actions
+## GitHub actions
 
-GitHub has a feature called **GitHub Actions** (GHA) that can be used to automate testing. The GHA is executed whenever a push is made to a branch in your repository. The bots will show the results of the GHA in your PR when you create or update it. The GHA in the JDK project is configured to run a set of tests that is commonly known as **tier 1**. This is a relatively fast, small set of tests that tries to verify that your change didn't break the JDK completely. In tier 1 the JDK is built on a small set of platforms including (but not necessarily limited to) Linux, Windows, and MacOS, and a few tests are executed using these builds.
+GitHub has a feature called **GitHub actions** (GHA) that can be used to automate testing. The GHA is executed whenever a push is made to a branch in your repository. The bots will show the results of the GHA in your PR when you create or update it. The GHA in the JDK project is configured to run a set of tests that is commonly known as **tier 1**. This is a relatively fast, small set of tests that tries to verify that your change didn't break the JDK completely. In tier 1 the JDK is built on a small set of platforms including (but not necessarily limited to) Linux, Windows, and MacOS, and a few tests are executed using these builds.
 
 In addition to the testing you run manually before publishing your changes, it's recommended that you take advantage of this automated testing that the GHA offers. This will for instance allow you to run tests on platforms that you may not otherwise have access to. To enable this on your personal fork of the JDK on GitHub go to the "Actions" tab and click the big green button saying "I understand my workflows, go ahead and enable them". If you don't understand these workflows there's a link to the actual file that describes them right below the green button.
 

--- a/src/guide/working-with-the-legacy-mercurial-servers.md
+++ b/src/guide/working-with-the-legacy-mercurial-servers.md
@@ -221,7 +221,7 @@ In order to push changesets into the parent repository, some additional configur
 
 ### Get your SSH key installed
 
-First you should create a new SSH key. See [Generating an SSH key] for guidance on how to do that. Your public key (`~/.ssh/id_rsa.pub`) should be mailed as an attachment along with your JDK username to [keys(at)openjdk.org](mailto:keys-at-openjdk.org). An administrator will install your key on the server and notify you on completion. This process may take a couple of days.
+First you should create a new SSH key. See [Generating an SSH key] for guidance on how to do that. Your public key (`~/.ssh/id_rsa.pub`) should be mailed as an attachment along with your JDK username to [keys@openjdk.org](mailto:keys@openjdk.org). An administrator will install your key on the server and notify you on completion. This process may take a couple of days.
 
 > ---
 >


### PR DESCRIPTION
* Make all headers follow the same style
* Make code examples use ~~~ instead of four space indentation
* Fix email adresses to be actual adresses
* Add link to jtreg FAQ
* Add comment about the name space for noreg-labels

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/guide pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/90.diff">https://git.openjdk.org/guide/pull/90.diff</a>

</details>
