### PR TITLE
hs_err.log files in bug reports

### DIFF
--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -42,7 +42,7 @@ A few things to keep in mind when filing a new bug:
 
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
 
-### Sensitive information (hs_err.log)
+### Sensitive information (e.g. hs_err.log)
 
 It may sound obvious, but avoid placing sensitive information in bug reports. Things like user names, IP addresses, host names, and exact version information of third party libraries etc may be crucial to be able to debug in some cases, but could also help an attacker gain information about your system. JBS is a public database that anyone can search, so be mindful of what you place there. In particular when attaching log files like the hs_err.log you should make sure that you are comfortable with sharing the details exposed in it. Sometimes it may be better to leave a comment saying that these details can be obtained on request.
 

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -42,6 +42,12 @@ A few things to keep in mind when filing a new bug:
 
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
 
+### Sensitive information (hs_err.log)
+
+It may sound obvious, but avoid placing sensitive information in bug reports. Things like user names, IP addresses, host names, and exact version information of third party libraries etc may be crucial to be able to debug in some cases, but could also help an attacker gain information about your system. JBS is a public database that anyone can search, so be mindful of what you place there. In particular when attaching log files like the hs_err.log you should make sure that you are comfortable with sharing the details exposed in it. Sometimes it may be better to leave a comment saying that these details can be obtained on request.
+
+If you file a bug through the [Bug Report Tool](https://bugreport.java.com/) there's a specific field that should be used to place sensitive information like this. Information placed there will not be part of the public bug report.
+
 ## Resolved - Incomplete
 
 To resolve an issue as `Incomplete` is JBS lingo for "Need More Information". An issue that is `Resolved - Incomplete` is *not* closed but more information is needed to be able to work on it. If no more information is obtained within reasonable time the issue should be closed (`Closed - Incomplete`). Closing a resolved issue is done using the `Verify` option.

--- a/src/guide/the-jdk-release-process.md
+++ b/src/guide/the-jdk-release-process.md
@@ -63,10 +63,11 @@ To clarify, as soon as you know that there is a fix that needs to go into the st
 * Set JDK-yyy's [Fix Version/s]{.jbs-field} to the release currently being developed in mainline
 * Add a comment describing the situation
 * Set the [Priority]{.jbs-field} to be relatively high (e.g., P3)
+* Make yourself a watcher of JDK-xxx so that you get a notification when it's forward ported
 
 Then, you have to wait until the JDK-xxx fix is forward ported to mainline before actually fixing JDK-yyy. Making these settings in JDK-yyy will help ensure that it won't be missed.
 
-There are also examples in JBS where JDK-yyy has been created as a sub-task of JDK-xxx. This works, but isn't recommended since JDK-yyy stands a higher risk of being missed when it's not of type *Bug* but rather a *sub-task* of an already closed issue. Also see [Backing out a change](#backing-out-a-change) for reference.
+There are examples in JBS where JDK-yyy has been created as a sub-task of JDK-xxx. This is **not** recommended since JDK-yyy stands a higher risk of being missed when it's not of type *Bug* but rather a *sub-task* of an already closed issue. In general it's not recommended to have open sub-tasks of closed issues - an issue shouldn't be closed unless all it's sub-tasks are closed. Also see [Backing out a change](#backing-out-a-change) for reference.
 
 ::: {.box}
 [To the top](#){.boxheader}


### PR DESCRIPTION
Added a section to inform about sensitive information in hs_err.log files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [f8df3bd9](https://git.openjdk.org/guide/pull/95/files/f8df3bd9824509c98ec2d4a307fcd2a8fd8b41be)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - Committer) ⚠️ Review applies to [f8df3bd9](https://git.openjdk.org/guide/pull/95/files/f8df3bd9824509c98ec2d4a307fcd2a8fd8b41be)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/guide pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/95.diff">https://git.openjdk.org/guide/pull/95.diff</a>

</details>
