### PR TITLE
More details around the jtreg bug tag

### DIFF
--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -54,7 +54,7 @@ There are several other tags that can be used in jtreg tests. You can for instan
 @bug 8272373
 ~~~
 
-You can add several bug ids in the same `@bug` tag, separated by a single space. These bug ids should refer to bugs that are reproduced by this test. JBS issues that track changes to the test itself are not listed here.
+You can add several bug ids in the same `@bug` tag, separated by a single space. These bug ids listed here should refer to bugs for which this test is verifying the fix. JBS issues that track changes to the test itself are not listed here.
 
 You can also specify a number of requirements that must be fulfilled for jtreg to execute the test.
 

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -54,7 +54,7 @@ There are several other tags that can be used in jtreg tests. You can for instan
 @bug 8272373
 ~~~
 
-You can add several bug ids in the same `@bug` tag, separated by a single space. These bug ids listed here should refer to bugs for which this test is verifying the fix. JBS issues that track changes to the test itself are not listed here.
+You can add several bug ids in the same `@bug` tag, separated by a single space. The bug ids listed here should refer to bugs for which this test is verifying the fix. JBS issues that track changes to the test itself are not listed here.
 
 You can also specify a number of requirements that must be fulfilled for jtreg to execute the test.
 

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -54,7 +54,7 @@ There are several other tags that can be used in jtreg tests. You can for instan
 @bug 8272373
 ~~~
 
-You can add several bug ids in the same `@bug` tag, separated by a single space. The bug ids listed here should refer to bugs for which this test is verifying the fix. JBS issues that track changes to the test itself are not listed here.
+You can add several bug ids in the same `@bug` tag, separated by a single space. These bug ids refer to product bugs for which a fix is verified by this test. JBS issues that track changes to the test itself are not listed here.
 
 You can also specify a number of requirements that must be fulfilled for jtreg to execute the test.
 

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -48,13 +48,15 @@ public class TestXY {
 
 This example only utilizes three jtreg specific tags, `@test`, `@summary`, and `@run`. `@test` simply tells jtreg that this class is a test, and `@summary` provides a description of the test. `@run` tells jtreg how to execute the test. In this case we simply tell jtreg to execute the main method of the class `TestXY`. `@run` isn't strictly necessary for jtreg to execute the test, an implicit `@run` tag will be added if none exists. However, for clarity and in order to avoid bugs it's recommended to always explicitly use the `@run` tag.
 
-There are several other tags that can be used in jtreg tests. You can for instance associate the test with a specific bug that this test is a regression test for.
+There are several other tags that can be used in jtreg tests. You can for instance associate the test with a specific bug that this test is a regression test for. The bug id is written without the `JDK-` prefix.
 
 ~~~
-@bug 7000001
+@bug 8272373
 ~~~
 
-Or you can specify a number of requirements that must be fulfilled for jtreg to execute the test.
+You can add several bug ids in the same `@bug` tag, separated by a single space. These bug ids should refer to bugs that are reproduced by this test. JBS issues that track changes to the test itself are not listed here.
+
+You can also specify a number of requirements that must be fulfilled for jtreg to execute the test.
 
 ~~~
 @requires docker.support
@@ -63,7 +65,7 @@ Or you can specify a number of requirements that must be fulfilled for jtreg to 
 @requires os.arch=="x86_64" | os.arch=="amd64"
 ~~~
 
-You can also specify if the test requires specific modules, and you can specify command line flags and run the test in several different ways.
+And you can specify if the test requires specific modules, or command line flags to run the test in several different ways.
 
 ~~~
 @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Minor change to clarify what kind of issues to refer to with the jtreg bug tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [feecd73e](https://git.openjdk.org/guide/pull/96/files/feecd73e0e4265203d7b0f76c89b57e56ef0b329)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - no project role) ⚠️ Review applies to [feecd73e](https://git.openjdk.org/guide/pull/96/files/feecd73e0e4265203d7b0f76c89b57e56ef0b329)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/guide pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/96.diff">https://git.openjdk.org/guide/pull/96.diff</a>

</details>
