### PR TITLE
RN-Change is default

### DIFF
--- a/src/guide/release-notes.md
+++ b/src/guide/release-notes.md
@@ -112,7 +112,7 @@ Unless labeled otherwise it will be assumed that the release note documents a ch
 :   Used to indicate that the release note is only relevant for a specific JDK distribution. E.g. [RN-Oracle]{.label}
 
 [[~~RN-Change~~]{.jbs-label}]{#RN-Change}
-:   Deprecated.
+:   Deprecated. This is the default and no label is needed to indicate this.
 
 ## Querying the release notes
 


### PR DESCRIPTION
Clarification that RN-Change is the default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - no project role)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - no project role)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/guide pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/99.diff">https://git.openjdk.org/guide/pull/99.diff</a>

</details>
