### PR TITLE
Updates to the JBS section of the OpenJDK Dev Guide

### DIFF
--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -66,8 +66,9 @@ A few things to keep in mind when filing an issue:
 * Set [Affects Version/s]{.jbs-field} to the earliest JDK version(s) where the failure was seen.
     * If the failure is found in an update train of the JDK (e.g. 11.0.x), please make an effort to see if it is also present in [mainline](https://github.com/openjdk/jdk).
 * Set the priority
-    * It's not the reporter's responsibility to set a correct priority, but a qualified guess is always better than the default.
-    * To help with setting the right priority, consider things like how the bug impacts the product and our testing, how likely is it that the bug is triggered, how difficult is it to work around, and whether it's a regression, since that may break existing applications. Regressions are often higher priority than long-standing bugs and may block a release if not fixed. An example of a P1 would be an issue that is blocking a build or a release, whereas a P5 would be a minor typo in a code comment - most bugs will be P3 or P4.
+    * It's not the reporter's responsibility to set a correct priority, but a qualified guess is always better than the default - in JBS the range of priorities go from P1 (High/Important) to P5 (Very Low/Not Important), with the default being P4.
+    *  If you have a sense that the issue is critical, or not critical at all, then adjusting the priority higher or lower makes sense, otherwise leave it as the default.
+    * When setting the priority, consider things like how the bug impacts the product and our testing, how likely is it that the bug is triggered, how difficult is it to work around, and whether it's a regression, since that may break existing applications. Regressions are often higher priority than long-standing bugs and may block a release if not fixed. An example of a P1 would be an issue that is blocking a build or a release, whereas a P5 would be a minor typo in a code comment.
 * In the [Description]{.jbs-field}, always include (if possible):
     * error messages
     * assert messages

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -386,7 +386,7 @@ This table contains some frequently used JBS labels and their meaning. Please he
   <tr>
     <td class="dictionary">[*(Rel)*[-na]{.jbs-label}]{#rel-na}</td>
     <td class="dictionary">
-      The [Affects Version/s]{.jbs-field} field is used to indicate the releases where an issue has been seen - it is implied that the issue is also applicable to newer releases. Where this is not the case - for instance a bug in code that was removed in *(Rel)* - then use the *(Rel)-na* to indicate this. Note that there should only be **one** *(Rel)*[-na]{.jbs-label} label on any JBS issue. 
+      The [Affects Version/s]{.jbs-field} field is used to indicate the releases where an issue has been seen - it is implied that the issue is also applicable to newer releases. Where this is not the case - for instance a bug in code that was removed in *(Rel)* - then use the *(Rel)-na* to indicate this. Note that there should only be **one** *(Rel)*[-na]{.jbs-label} label on any JBS issue.
     </td>
   </tr>
   <!-- Team -->

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -55,10 +55,11 @@ Notes:
 * a [Bug]{.jbs} or [Enhancement]{.jbs-field} should only be used if the work is expected to result in a change in a code repository. A [Bug]{.jbs-field} or [Enhancement]{.jbs-field} with resolution Fixed is required to have a corresponding changeset in one of the OpenJDK repositories.
 
 <br>
-A few things to keep in mind when filing an issue to report a problem:
+A few things to keep in mind when filing an issue:
 
-* Before filing, verify that there isn't an issue already filed.
+* Before filing, verify that there isn't an open issue already filed,
     * Search [JBS](https://bugs.openjdk.org/) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
+    * if you find a similar issue that was closed as "not reproducible" then it may be appropriate to re-open that one - if you don't have direct access to JBS you can file a bug at [bugs.java.com](https://java.bugs.com) requesting that it be reopened.
 * Make a reasonable attempt to narrow down which build or release the failure first appeared in.
 * Add relevant [Labels]{.jbs-field} like [[intermittent]{.jbs-label}](#intermittent), [[regression]{.jbs-label}](#regression), [[noreg-self]{.jbs-label}](#noreg-self), [[tier1]{.jbs-label}](#tier) etc.
     * For more information see the [JBS Label Dictionary](#jbs-label-dictionary)
@@ -74,12 +75,13 @@ A few things to keep in mind when filing an issue to report a problem:
     * command line information
     * relevant information from the logs
     * full name of any failing tests
+* If the information provided is long it should be added as attachments
 * Avoid including in the description or comments:
     * personal information
     * passwords, logins, machine names
     * logs which may include sensitive data
 * If the failure isn't reproducible with an existing OpenJDK test, attach a reproducer if possible, having a test case will decrease the time required to resolve the issue.
-* Only set [CPU]{.jbs-field} and/or [OS]{.jbs-field} fields if the bug **ONLY** happens on that particular platform or set of platforms.
+* In general the [CPU]{.jbs-field} and/or [OS]{.jbs-field} fields should not be set. **ONLY** use them if you know that the issue is only relevant to a particular platform or set of platforms.
 * Provide the output of `java -version`  whenever possible - this version information is particularly critical for hangs, JVM bugs, and network issues.
 * Always file separate bugs for different issues.
     * If two crashes look related, but not similar enough to be sure they are the same, it's easier to later close a bug as a duplicate than it is to separate out one bug into two.
@@ -109,7 +111,7 @@ JBS only has a few states in which an issue can be in:
 </tr>
 <tr>
     <td class="dictionary">[Open]{.jbs-field}</td>
-    <td class="dictionary">Most straightforward issues stay in this state until they are closed.  If the issue has some attention then use [In Progress]{.jbs-field} to show more clearly that the issue is being worked</td>
+    <td class="dictionary">Once the issue has been triaged it will be in the [Open]{.jbs-field} state and will stay here until the assignee decides to work on it, at which point it is encouraged that the "Start Work" option be selected to move it to [In Progress]{.jbs-field}</td>
 </tr>
 <tr>
     <td class="dictionary">[In Progress]{.jbs-field}</td>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -26,7 +26,7 @@ The most common **issue** types are:
 <tr style="text-align:left;"><th>Issue Type</th><th>Covers</th></tr>
 <tr>
     <td class="dictionary">[Bug]{.jbs-field}</td>
-    <td class="dictionary">A "bug" should relate to functional correctness - a deviation from behavior that can be tied back to a specification. Anything else, including performance concerns, is generally not a bug, but an enhancement. Though it is not clear cut as a significant performance regression may be classified as a "bug", for example.</td>
+    <td class="dictionary">A "bug" should relate to functional correctness - a deviation from behavior that can be tied back to a specification. Anything else, including performance concerns, is generally not a bug, but an enhancement. Though it is not clear-cut as a significant performance regression may be classified as a "bug", for example.</td>
 </tr>
 <tr>
     <td class="dictionary">[Enhancement]{.jbs-field}</td>
@@ -209,7 +209,7 @@ At this point move the issue into the [Open]{.jbs-field} state.
 
 ### Sensitive information (e.g. hs_err.log)
 
-It may sound obvious, but avoid placing sensitive information in bug reports. Things like user names, IP addresses, host names, and exact version information of third party libraries etc may be crucial to be able to debug in some cases, but could also help an attacker gain information about your system. JBS is a public database that anyone can search, so be mindful of what you place there. In particular when attaching log files like the hs_err.log you should make sure that you are comfortable with sharing the details exposed in it. Sometimes it may be better to leave a comment saying that these details can be obtained on request.
+It may sound obvious, but avoid placing sensitive information in bug reports. Things like usernames, IP addresses, host names, and exact version information of third party libraries etc. may be crucial to be able to debug in some cases, but could also help an attacker gain information about your system. JBS is a public database that anyone can search, so be mindful of what you place there. In particular when attaching log files like the hs_err.log you should make sure that you are comfortable sharing the details exposed in it. Sometimes it may be better to leave a comment saying that these details can be obtained on request.
 
 If you file a bug through the [Bug Report Tool](https://bugreport.java.com/) there's a specific field that should be used to place sensitive information like this. Information placed there will not be part of the public bug report.
 
@@ -240,7 +240,7 @@ Once the work on an issue has been completed the issue should be in a "closed" s
         <li>Once a bug is marked as fixed there is now the option of someone, other than the person that fixed it, of marking it as [Verified]{.jbs-field} to confirm that the issue is fixed after testing; marking it as [Fix Failed]{.jbs-field} if it did not solve the issue; or, [Not Verified]{.jbs-field} to indicate that it wasn't explicitly tested.  Note that the UI does not highlight when [Fix Failed]{.jbs-field} has been set, you need to look for the [Verification]{.jbs-label} field at the bottom of the left-hand colum in the Details section.</li>
 </ul><br />
     If there is not a fix in the repo (and so no associated changeset) then the issue should not be marked as [Fixed]{.jbs-field}, but set to [Delivered]{.jbs-field}.<br />
-    If you know that an issue was fixed, try searching for the issue that resolved it and close it as a duplicate of that issue. If that would entail a significant effort, and/or it isn't a critical issue, close it out as Not Reproducible.<br />
+    If you know that an issue was fixed, try searching for the issue that resolved it and close it as a duplicate of that issue. If that entails a significant effort, and/or it isn't a critical issue, close it out as Not Reproducible.<br />
     </td>
 </tr>
 <tr>
@@ -405,7 +405,7 @@ This table contains some frequently used JBS labels and their meaning. Please he
   <tr>
     <td class="dictionary">[*(Team)*[-triage-]{.jbs-label}*(Rel)*]{#team-triage-rel}</td>
     <td class="dictionary">
-      Used to indicate that *(Team)* has triaged this issue for release *(Rel)*. It's encouraged that all open bugs are triaged on a regular basis so that old bugs aren't forgotten. It's therefore common to see several triage labels on the same issue which helps keeping track of which bugs has been triaged for each release. E.g., [oracle-triage-13]{.jbs-label}
+      Used to indicate that *(Team)* has triaged this issue for release *(Rel)*. It's encouraged that all open bugs are triaged on a regular basis so that old bugs aren't forgotten. It's therefore common to see several triage labels on the same issue which helps keeping track of which bugs have been triaged for each release. E.g., [oracle-triage-13]{.jbs-label}
 
       There are many label variants that include the word triage in some form. The form described above is the only one recommended. Please refrain from using other forms.
     </td>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -20,20 +20,25 @@ When filing an Issue, try to make the report as complete as possible in order to
 
 #### Types of Issues
 
-The most common Issue types are:
+The most common [Issue]{.jbs-field} types are:
 <br />
-<table class="dictionary" summary="JBS Label Dictionary">
-  <tr style="text-align:left;"><th>Type</th><th>Covers</th></tr>
+<table class="dictionary" summary="JBS Issue Types">
+<tr style="text-align:left;"><th>Issue Type</th><th>Covers</th></tr>
 <tr>
     <td class="dictionary">[Bug]{.jbs-field}</td>
     <td class="dictionary">Used when reporting a problem: crashes; hangs; failures of functionality etc.</td>
 </tr>
 <tr>
-    <td class="dictionary"><i>Improvement</i></td>
-    <td class="dictionary">When requesting an improvement in the JDK, the issue type used depends on the size/scope of the improvement:<br />
-    ([Enhancement]{.jbs-field}) - for a small improvement to existing functionality<br />
-    ([New Feature]{.jbs-field}) - not recommended to use<br />
-([JEP]{.jbs-field}) - for a proposal for a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1)</td>
+    <td class="dictionary">[Enhancement]{.jbs-field}</td>
+    <td class="dictionary">For a small improvement to existing functionality<br />
+</tr>
+<tr>
+    <td class="dictionary">[New Feature]{.jbs-field}</td>
+    <td class="dictionary">Not recommended to use<br /></td>
+</tr>
+<tr>
+    <td class="dictionary">[JEP]{.jbs-field}</td>
+    <td class="dictionary">For a proposal for a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1)</td>
 </tr>
 <tr>
     <td class="dictionary">[Sub-task]{.jbs-field}</td>
@@ -41,13 +46,10 @@ The most common Issue types are:
 </tr>
 <tr>
     <td class="dictionary">[Task]{.jbs-field}</td>
-    <td class="dictionary">Where something needs to happen other than a code change - a request for a new JBS version value for example</td>
-</tr>
-<tr>
-    <td class="dictionary"><i>Vulnerability</i></td>
-    <td class="dictionary">If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org). <br>Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels. <br>See [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.</td>
+    <td class="dictionary">Where something needs to happen other than a code change - for example a request for a new JBS version, or other work associated with a release</td>
 </tr>
 </table>
+Note: If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org), also use this alias if you find an existing report which may be a vulnerability. Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels - see [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.
 
 <br>
 A few things to keep in mind when filing an issue to report a problem:
@@ -87,10 +89,10 @@ Things to keep in mind when requesting an improvement:
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
 
 ### Implementing a Large Change
-When managing the work for a large change, especially when the work involves multiple engineers, it is recommended that the work is distributed across one or more "implementation" issues which should be linked to the main [Enhancement]{.jbs-field} with a "blocks" link along with any relevant CSRs. The [Enhancement]{.jbs-field} should not be considered done until all the blocking element are completed.  The use of subTasks for [Enhancement]{.jbs}s is not recommended unless all the [Sub-task]{.jbs-field}s are relevant to the fix, if it were to be backported.
+When managing the work for a large change, especially when the work involves multiple engineers, it is recommended that the work is distributed across one or more "implementation" issues which should be linked to the main [Enhancement]{.jbs-field} with a "blocks" link along with any relevant CSRs. The [Enhancement]{.jbs-field} should not be considered done until all the blocking elements are completed.  The use of subTasks for [Enhancement]{.jbs}s is not recommended unless all the [Sub-task]{.jbs-field}s are relevant to the fix, if it were to be backported.
 
 ### Implementing a JEP
-It recommended that for [JEP]{.jbs-field}s the implementation is spread across one or more [Enhancement]{.jbs-field}s as above.
+It recommended that for [JEP]{.jbs-field}s that the implementation is spread across one or more [Enhancement]{.jbs-field}s as above.
 
 ## Issue states
 
@@ -103,15 +105,15 @@ JBS only has a few states in which an issue can be in:
     <td class="dictionary">Initial state after an issue is filed. [Bugs]{.jbs-field} in the JDK Project must be taken out of the [New]{.jbs-field} state (Triaged - see below) in a timely manner. In general, this is recommended to be done for all issue types and projects as a sign that the issue is correctly filed, and will be seen by the right group - this is especially important towards the end of a release.</td>
 </tr>
 <tr>
-    <td class="dictionary">Open</td>
-    <td class="dictionary">Most straightforward issues stay in this state until they are closed.  If the issue has some attention then use "In Progress" to show more clearly that the issue is being worked</td>
+    <td class="dictionary">[Open]{.jbs-field}</td>
+    <td class="dictionary">Most straightforward issues stay in this state until they are closed.  If the issue has some attention then use [In Progress]{.jbs-field} to show more clearly that the issue is being worked</td>
 </tr>
 <tr>
-    <td class="dictionary">In Progress</td>
-    <td class="dictionary">The <i>In Progress</i> state has the option of the sub-states ([Understanding]{.jbs-field}): [Cause Known]{.jbs-field}, [Fix Understood]{.jbs-field}, [In Review]{.jbs-field}.</td>
+    <td class="dictionary">[In Progress]{.jbs-field}</td>
+    <td class="dictionary">The [In Progress]{.jbs-field} state has the option of the sub-states ([Understanding]{.jbs-field}): [Cause Known]{.jbs-field}, [Fix Understood]{.jbs-field}, [In Review]{.jbs-field}.</td>
 </tr>
 <tr>
-    <td class="dictionary">Closed/Resolved</td>
+    <td class="dictionary">[Closed]{.jbs-field}/[Resolved]{.jbs-field}</td>
     <td class="dictionary">While [Closed]{.jbs-field} and [Resolved]{.jbs-field} are essentially equivalent, when it comes to fixing issues there is an additional [Verify]{.jbs-field} step available between the [Resolved]{.jbs-field} and [Closed]{.jbs-field} states</td>
 </tr>
 </table>
@@ -147,9 +149,9 @@ Closed
   Open <--> InProgress(<font color=blue>IN PROGRESS)
   InProgress --> states
 
-  states(Fixed, Won't Fix, Duplicate etc.) --> Closed
+  states[Fixed, Won't Fix, Duplicate etc.] --> Closed
   states --> Resolved
-  Resolved[<font color=white>RESOLVED] -.-> Verify(Verify)
+  Resolved(<font color=white>RESOLVED) -.-> Verify[Verify]
   Verify --> Closed(<font color=green>CLOSED)
 end
 
@@ -168,11 +170,11 @@ style ClosedIncomplete fill:lightgreen
 
 ## Triaging an issue
 
-First give the issue a general [Review]{.jbs-field}
+First give the issue a general review
 
 1. If the issue is a duplicate, close it as such.
 1. If the issue belongs to a different area (it was filed in libraries, but it is an HotSpot issue), transfer it to the correct component/subcomponent making sure that the state remains [New]{.jbs-field}.
-1. If the issue is incomplete, add a comment noting what is needed and close the bug as [Resolved]{.jbs-field} - 'Incomplete'. If no more information is obtained within reasonable time, the issue should be closed (`Closed - Incomplete`).
+1. If the issue is incomplete, add a comment noting what is needed and close the bug as [Resolved]{.jbs-field} - 'Incomplete'. If no more information is obtained within reasonable time, the issue should be closed ([Closed]{.jbs-field} - `Incomplete`).
 
 Now that the issue is in the right component and has the basic information, the analysis continues to get a more detailed understanding of the issue, and what should be done:
 
@@ -205,16 +207,15 @@ If you file a bug through the [Bug Report Tool](https://bugreport.java.com/) the
 
 ## Updating an issue while fixing
 
-Once you are made, or you make yourself, the assignee of an Issue you take on the responsibility of moving the issue through to resolution and providing the current status, and ultimately leaving a record for others in the future to understand what happened.  There are no real rules for how you manage the bug while you are assigned to it, as it depends on the type and importance of an issue.  A simple update to the doc needs little to be done, fix the problem and close the issue; an intricate timing issue or crash should be handled differently - documenting your progress in identifying the problem (for example
+Once you are made, or you make yourself, the assignee of an Issue you take on the responsibility of moving the issue through to resolution and providing the current status, and ultimately leaving a record for others in the future to understand what happened.  There are no set rules for how you manage the bug while you are assigned to it, as it depends on the type and importance of an issue.  A simple update to the doc needs little to be done, fix the problem and close the issue; an intricate timing issue or crash should be handled differently - documenting your progress in identifying the problem (for example
 [JDK-8212207](https://bugs.openjdk.org/browse/JDK-8212207),
 [JDK-6984895](https://bugs.openjdk.org/browse/JDK-6984895),
 [JDK-8287982](https://bugs.openjdk.org/browse/JDK-8287982)
-), this is especially helpful if you ultimately move the Issue to a different area as you have found that the problem lies elsewhere or is closed as [Will Not Fix]{.jbs-field}.  Your updates can provide a resource to others to better understand the code. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is also important to write an evaluation when something is not fixed.
-
+), this is especially helpful if you ultimately move the Issue to a different area as you have found that the problem lies elsewhere, or is closed as [Will Not Fix]{.jbs-field}.  Your updates then provide a resource to others to better understand what has been done or the code. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is also important to write an evaluation when something is not fixed.
 
 Some additional fields should be filled in as you get a better understanding of the issue:
 - for a regression, if you identify the fix that caused it add a link to that issue (and add a [regression_]{.jbs-field}*(ID)* label) and set the _Introduced in Release_ field.
-- The description usually explains what went wrong and how the failure was found, then there's some investigation and eventually the root cause is found. At this point the Summary should be updated to correctly describe the bug. The Description however should remain a description of how the failure was found.
+- The [Description]{.jbs-field} usually explains what went wrong and how the failure was found, then there's some investigation and eventually the root cause is found. At this point the [Summary]{.jbs-field} should be updated to correctly describe the bug. The [Description]{.jbs-field} however should remain a description of how the failure was found.
 
 ## Resolving an issue
 
@@ -246,7 +247,7 @@ Once the work on an issue has been completed this should be indicated in JBS by 
 </tr>
 <tr>
     <td class="dictionary">[Cannot Reproduce]{.jbs-field}</td>
-    <td class="dictionary">Use when a reproducer is provided (or clear steps) but it is not possible to see the same behavior. Where feasible try on the release the issue was reported against, as a way of confirming that it is indeed addressed, rather than you not having the right environment in which to reproduce the issue</td>
+    <td class="dictionary">Use when a reproducer is provided (or clear steps) but it is not possible to see the same behavior. When you can't reproduce an issue, where feasible try on the release the issue was reported against, as a way of confirming that it is indeed addressed on the latest release, rather than you not having the right environment in which to reproduce the issue</td>
 </tr>
 <tr>
     <td class="dictionary">[Other]{.jbs-field}</td>
@@ -254,7 +255,7 @@ Once the work on an issue has been completed this should be indicated in JBS by 
 </tr>
 <tr>
     <td class="dictionary">[Future Project]{.jbs-field}</td>
-    <td class="dictionary"></td>
+    <td class="dictionary">This status is not recommended</td>
 </tr>
 <tr>
     <td class="dictionary">[External]{.jbs-field}</td>
@@ -278,7 +279,7 @@ Once the work on an issue has been completed this should be indicated in JBS by 
 </tr>
 <tr>
     <td class="dictionary">[Delivered]{.jbs-field}</td>
-    <td class="dictionary">Use to close out issues where a changeset is not produced, common examples are Release Notes</td>
+    <td class="dictionary">Use to close out issues where a change to the code is not required, common examples are Release Notes</td>
 </tr>
 <tr>
     <td class="dictionary">[Approved]{.jbs-field}</td>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -16,11 +16,11 @@ Depending on your role in OpenJDK you can either use the [Bug Report Tool](https
 are registered in the [OpenJDK Census](https://openjdk.org/census), you can report the issue directly in [JBS](https://bugs.
 openjdk.org/).
 
-When filing an Issue, try to make the report as complete as possible in order to make it easier to triage, investigate and resolve the issue.
+When filing an issue, try to make the report as complete as possible in order to make it easier to triage, investigate and resolve the issue.
 
-#### Types of Issues
+#### Types of issues
 
-The most common **Issue** types are:
+The most common **issue** types are:
 <br />
 <table class="dictionary" summary="JBS Issue Types">
 <tr style="text-align:left;"><th>Issue Type</th><th>Covers</th></tr>
@@ -38,7 +38,7 @@ The most common **Issue** types are:
 </tr>
 <tr>
     <td class="dictionary">[JEP]{.jbs-field}</td>
-    <td class="dictionary">For a proposal of a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1).</td>
+    <td class="dictionary">For a proposal of a significant change or new feature which will take 4 or more weeks of work - see [JEP-1](https://openjdk.org/jeps/1).</td>
 </tr>
 <tr>
     <td class="dictionary">[Sub-task]{.jbs-field}</td>
@@ -46,13 +46,13 @@ The most common **Issue** types are:
 </tr>
 <tr>
     <td class="dictionary">[Task]{.jbs-field}</td>
-    <td class="dictionary"> Tasks are used to track work that is not expected to result in a change in any code repository. They are used to track non-repo changes or related activities such as a new JBS version number, a build request, an update to a document etc.</td>
+    <td class="dictionary"> Tasks are used to track work that is not expected to result in a change in any code repository. They are used related activities such as a new JBS version number, a build request, an update to a document etc.</td>
 </tr>
 </table>
 Notes:
 
-* If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org), also use this alias if you find an existing report which may be a vulnerability. Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels - see [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.
-* a [Bug]{.jbs} or [Enhancement]{.jbs-field} should only be used if the work is expected to result in a change in a code repository. A [Bug]{.jbs-field} or [Enhancement]{.jbs-field} with resolution Fixed is required to have a corresponding changeset in one of the OpenJDK repositories.
+* If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org). Also use this alias if you find an existing report which may be a vulnerability - please do *not* report or discuss potential vulnerabilities on any open lists or other public channels - see [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.
+* A [Bug]{.jbs} or [Enhancement]{.jbs-field} should only be used if the work is expected to result in a change in a code repository. A [Bug]{.jbs-field} or [Enhancement]{.jbs-field} with resolution Fixed is required to have a corresponding changeset in one of the OpenJDK repositories.
 
 <br>
 A few things to keep in mind when filing an issue:
@@ -76,7 +76,7 @@ A few things to keep in mind when filing an issue:
     * command line information
     * relevant information from the logs
     * full name of any failing tests
-* If the information provided is long it should be added as attachments
+    * If the information provided is long it should be added as attachments
 * Avoid including in the description or comments:
     * personal information
     * passwords, logins, machine names
@@ -89,7 +89,7 @@ A few things to keep in mind when filing an issue:
 
 Things to keep in mind when requesting an improvement:
 
-* Unlike reporting a problem, when it comes to improvements what constitutes a reasonable request can take discussion, and in general it is encouraged that the mailing list for the area is used to suggest an improvement before filing.
+* Unlike reporting a problem, when it comes to improvements, what constitutes a reasonable request can take discussion, and in general it is encouraged that the mailing list for the area is used to suggest an improvement before filing.
 * Enhancements to The Java Language Specification and The JVM Specification are managed through the [Java Community Process](http://jcp.org/).
 
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
@@ -98,7 +98,7 @@ To find out which component to use for different bugs, consult the [directory to
 When managing the work for a large change, especially when the work involves multiple engineers, it is recommended that the work is distributed across one or more "implementation" issues which should be linked to the main [Enhancement]{.jbs-field} with a "blocks" link along with any relevant CSRs. The [Enhancement]{.jbs-field} should not be considered done until all the blocking elements are completed.  The use of subTasks for [Enhancement]{.jbs}s is not recommended unless all the [Sub-task]{.jbs-field}s are relevant to the fix, if it were to be backported, for example [JDK-8231641](https://bugs.openjdk.org/browse/JDK-8231641) or [JDK-8171407](https://bugs.openjdk.org/browse/JDK-8171407),
 
 ### Implementing a JEP
-It recommended that for [JEP]{.jbs-field}s that the implementation is spread across one or more [Enhancement]{.jbs-field}s as above.
+It is recommended that for [JEP]{.jbs-field}s that the implementation is spread across one or more [Enhancement]{.jbs-field}s as above.
 
 ## Issue states
 
@@ -187,12 +187,12 @@ When triaging an issue, first give it a general review
 Now that the issue is in the right component and has the basic information, the analysis continues to get a more detailed understanding of the issue, and what should be done:
 
 1. Ensure the priority is correct - an approach that has been used for getting a consistent view of priority is to consider three aspects of the issue: [Impact]{.jbs-field} or issue; [Likelihood]{.jbs-field} of it occurring; and, whether there is a [Workaround]{.jbs-field}. The higher the [Impact]{.jbs-field} and [Likelihood]{.jbs-field} the higher the priority; then, having a [Workaround]{.jbs-field} reduces that priority - but mostly where the Impact and Likelihood are not that severe.
-1. Ensure the 'Affects Version/s' field is correct (within reason)
+1. Ensure the [Affects Version]{jbs-field}/s field is correct (within reason)
     1. This may involve reproducing the bug, if doing so is fast and easy.
     1. In addition to the version where the bug was found, take special care to also investigate if the bug affects the supported releases - the latest LTS release and the latest six-month release.
     1. The affects version is not meant to be an exhaustive list of releases the issue is relevant to - it should initially be set to the release the issue was reproduced or identified on, and by implication it will be relevant on all releases past that point (see (Rel)-na label). If it is later found to be applicable to an earlier release family then adding that earlier release is encouraged if the issue needs to be fixed in that release.
     1.  Do not add additional release values to `Affected Versions` for the same release family: if there is the value 11.0.2 do not add 11.0.5, 11.0.7 etc.  Adding an additional value for a separate release family where it is still reproducible, 12 say, is not necessary but ok, especially if the bug is old (reported on 8 say) but still relevant to the latest release (20 say).
-1. Set the 'Fix Version'
+1. Set the [Fix Version]{.jbs-field}
     1. A bug should be fixed first in the most recent version where it exists, if you don't know what version it will go into set it to `tbd`.
     1. If the bug also exists in older versions it may require backporting
         * The decision to backport should be made inline with the guidelines of the lead for the release
@@ -202,7 +202,7 @@ Now that the issue is in the right component and has the basic information, the 
     1. Bugs where behavior has _incorrectly_ changed from a previous build or release : 'regression'
     1. Bugs that do not affect product code, but are only against the regression test: 'noreg-self'
     1. Issues that seem to be trivial to fix: 'starter'
-    1. RFEs that are pure cleanups: 'noreg-cleanup'
+    1. Enhancements that are pure cleanups: 'noreg-cleanup'
     1. Project specific issues usually have their own labels as well
 
 At this point move the issue into the [Open]{.jbs-field} state.
@@ -215,14 +215,14 @@ If you file a bug through the [Bug Report Tool](https://bugreport.java.com/) the
 
 ## Updating an issue while fixing
 
-Once you are made, or you make yourself, the assignee of an Issue you take on the responsibility of moving the issue through to resolution and providing the current status, and ultimately leaving a record for others in the future to understand what happened.  There are no set rules for how you manage the bug while you are assigned to it, as it depends on the type and importance of an issue.  A simple update to the doc needs little to be done, fix the problem and close the issue; an intricate timing issue or crash should be handled differently - documenting your progress in identifying the problem (for example
+Once you are made, or you make yourself, the assignee of an issue you take on the responsibility of moving the issue through to resolution - providing the current status, and ultimately leaving a record for others in the future to understand what happened.  There are no set rules for how you manage the bug while you are assigned to it, as it depends on the type and importance of an issue.  A simple update to the doc needs little to be done, fix the problem and close the issue; an intricate timing issue or crash should be handled differently - documenting your progress in identifying the problem (for example
 [JDK-8212207](https://bugs.openjdk.org/browse/JDK-8212207),
 [JDK-6984895](https://bugs.openjdk.org/browse/JDK-6984895),
 [JDK-8287982](https://bugs.openjdk.org/browse/JDK-8287982)
-), this is especially helpful if you ultimately move the Issue to a different area as you have found that the problem lies elsewhere, or is closed as [Will Not Fix]{.jbs-field}.  Your updates then provide a resource to others to better understand what has been done or the code. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is important.
+), this is especially helpful if you ultimately move the issue to a different area as you have found that the problem lies elsewhere, or is closed as [Will Not Fix]{.jbs-field}.  Your updates then provide a resource to others to better understand what has been done or the code itself. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is important.
 
 Some additional fields should be filled in as you get a better understanding of the issue:
-- for a regression, if you identify the fix that caused it add a link to that issue (and add a [regression_]{.jbs-field}*(ID)* label) and set the _Introduced in Release_ field.
+- for a regression, if you identify the fix that caused it, add a link to that issue (and add a [regression_]{.jbs-field}*(ID)* label) and set the _Introduced in Release_ field.
 - The [Description]{.jbs-field} usually explains what went wrong and how the failure was found, then there's some investigation and eventually the root cause is found. At this point the [Summary]{.jbs-field} should be updated to correctly describe the bug. The [Description]{.jbs-field} however should remain a description of how the failure was found.
 
 ## Resolving an issue
@@ -235,7 +235,7 @@ Once the work on an issue has been completed the issue should be in a "closed" s
     <td class="dictionary">[Fixed]{.jbs-field}</td>
     <td class="dictionary">If a change is required in a repo to address an issue then the [Fixed]{.jbs-field} status should be used - for the JDK project in almost all cases the bots will transition the issue to [Fixed]{.jbs-field} when the changeset is pushed to the repo.<br />
 <ul>
-        <li>Once a bug is marked as fixed there is now the option of someone, other than the person that fixed it, marking it as [Verified]{.jbs-field} to confirm that the issue is fix after testing; marking it as [Fix Failed]{.jbs-field} if it did not solve the issue; or, [Not Verified]{.jbs-field} to indicate that it wasn't explicitly tested.  Note that the UI does not highlight when [Fix Failed]{.jbs-field} has been set, you need to look for the [Verification]{.jbs-label} Field at the bottom of the left-hand colum in the Details section.</li>
+        <li>Once a bug is marked as fixed there is now the option of someone, other than the person that fixed it, of marking it as [Verified]{.jbs-field} to confirm that the issue is fixed after testing; marking it as [Fix Failed]{.jbs-field} if it did not solve the issue; or, [Not Verified]{.jbs-field} to indicate that it wasn't explicitly tested.  Note that the UI does not highlight when [Fix Failed]{.jbs-field} has been set, you need to look for the [Verification]{.jbs-label} field at the bottom of the left-hand colum in the Details section.</li>
 </ul><br />
     If there is not a fix in the repo (and so no associated changeset) then the issue should not be marked as [Fixed]{.jbs-field}, but set to [Delivered]{.jbs-field}.<br />
     If you know that an issue was fixed, try searching for the issue that resolved it and close it as a duplicate of that issue. If that would entail a significant effort, and/or it isn't a critical issue, close it out as Not Reproducible.<br />
@@ -247,8 +247,8 @@ Once the work on an issue has been completed the issue should be in a "closed" s
 </tr>
 <tr>
     <td class="dictionary">[Duplicate]{.jbs-field}</td>
-    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the new issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok. <br />
-     Note: if you use "Close" button then you get the UI that allows you to set the Resolution as "Duplicate" and link to the issue which is duplicated. However, if you use "Resolve" then the ability to add the link in the UI is not there, and you need to make sure you remember to manually link in the duplicate issue.</td>
+    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the newer issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok. <br />
+     Note: if you use "Close" button when closing the issue, then you get the UI that allows you to set the Resolution as [Duplicate]{.jbs-field} and link to the issue which is duplicated; however, if you use "Resolve" then the ability to add the link in the UI is not there, and you need to make sure you remember to manually link in the duplicate issue.</td>
 </tr>
 <tr>
     <td class="dictionary">[Incomplete]{.jbs-field}</td>
@@ -665,7 +665,7 @@ Examples:  If a bug fix only corrects a change in the build system, then add the
   <tr>
     <td class="dictionary">[[regression]{.jbs-label}]{#regression}</td>
     <td class="dictionary">
-      Used to identify regressions. A regression is where behavior has _incorrectly_ changed from a previous build or release. Ideally all regressions must be fixed in the following release. All regressions must have the [Affects Version/s]{.jbs-field} set.
+      Used to identify regressions. A regression is where behavior has _incorrectly_ changed from a previous build or release. Ideally all regressions are identified and fixed before they are released, if not they must be fixed at latest in the following release after they are identified. All regressions must have the [Affects Version/s]{.jbs-field} set.
     </td>
   </tr>
   <tr>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -225,6 +225,8 @@ Some additional fields should be filled in as you get a better understanding of 
 - for a regression, if you identify the fix that caused it, add a link to that issue (and add a [regression_]{.jbs-field}*(ID)* label) and set the _Introduced in Release_ field.
 - The [Description]{.jbs-field} usually explains what went wrong and how the failure was found, then there's some investigation and eventually the root cause is found. At this point the [Summary]{.jbs-field} should be updated to correctly describe the bug. The [Description]{.jbs-field} however should remain a description of how the failure was found.
 
+Note: if during your investigation of the bug you determine that the issue is in the wrong component, make sure to move it back to the [New]{.jbs-field} state before moving it to the new component, so that it will be picked up by the component's Triage team. Make sure there is a comment outlining the reason for the move, as explained above.
+
 ## Resolving an issue
 
 Once the work on an issue has been completed the issue should be in a "closed" state.  There are two "closed" states: [Resolved]{.jbs-field} and [Closed]{.jbs-field} which can be used interchangeably except in the case of [Fixed]{.jbs-field}, or when flagged as  [Incomplete]{.jbs-field} (See Triaging).

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -78,7 +78,7 @@ A few things to keep in mind when filing an issue to report a problem:
     * personal information
     * passwords, logins, machine names
     * logs which may include sensitive data
-* If the failure isn't reproducible with an existing OpenJDK test, attach a reproducer if possible, while in a number of cases it isn't possible, having a test case will decrease the time required to resolve the issue.
+* If the failure isn't reproducible with an existing OpenJDK test, attach a reproducer if possible, having a test case will decrease the time required to resolve the issue.
 * Only set [CPU]{.jbs-field} and/or [OS]{.jbs-field} fields if the bug **ONLY** happens on that particular platform or set of platforms.
 * Provide the output of `java -version`  whenever possible - this version information is particularly critical for hangs, JVM bugs, and network issues.
 * Always file separate bugs for different issues.
@@ -179,7 +179,7 @@ When triaging an issue, first give it a general review
 
 1. If the issue is a duplicate, close it as such.
 1. If the issue belongs to a different area (it was filed in libraries, but it is an HotSpot issue), transfer it to the correct component/subcomponent making sure that the state remains [New]{.jbs-field}.
-1. If the issue is incomplete, add a comment noting what is needed and close the bug as [Resolved]{.jbs-field} - 'Incomplete'. If no more information is obtained within reasonable time, the issue should be closed ([Closed]{.jbs-field} - `Incomplete`).
+1. If the issue is incomplete, add a comment noting what is needed and close the bug as [Resolved]{.jbs-field} - `Incomplete`. If no more information is obtained within reasonable time, the issue should be closed ([Closed]{.jbs-field} - `Incomplete`).
 
 Now that the issue is in the right component and has the basic information, the analysis continues to get a more detailed understanding of the issue, and what should be done:
 
@@ -196,7 +196,7 @@ Now that the issue is in the right component and has the basic information, the 
         * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo (see [Working with backports in JBS](#working-with-backports-in-jbs).
     1. Only one fixversion should ever be set, if the issue is to be fixed in additional releases then a separate backport must be created (see [Working with backports in JBS](#working-with-backports-in-jbs)).  There are exceptions to this rule for: CSRs; and, Release Notes.
 1. make sure the bug has all the required labels – see [JBS Label Dictionary](#jbs-label-dictionary)
-    1. bugs where behavior has _incorrectly_ changed from a previous release : 'regression'
+    1. bugs where behavior has _incorrectly_ changed from a previous build or release : 'regression'
     1. bugs that do not affect product code, but are only against the regression test: 'noreg-self'
     1. issues that seem to be trivial to fix: 'starter'
     1. RFEs that are pure cleanups: 'noreg-cleanup'
@@ -216,7 +216,7 @@ Once you are made, or you make yourself, the assignee of an Issue you take on th
 [JDK-8212207](https://bugs.openjdk.org/browse/JDK-8212207),
 [JDK-6984895](https://bugs.openjdk.org/browse/JDK-6984895),
 [JDK-8287982](https://bugs.openjdk.org/browse/JDK-8287982)
-), this is especially helpful if you ultimately move the Issue to a different area as you have found that the problem lies elsewhere, or is closed as [Will Not Fix]{.jbs-field}.  Your updates then provide a resource to others to better understand what has been done or the code. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is also important to write an evaluation when something is not fixed.
+), this is especially helpful if you ultimately move the Issue to a different area as you have found that the problem lies elsewhere, or is closed as [Will Not Fix]{.jbs-field}.  Your updates then provide a resource to others to better understand what has been done or the code. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is important.
 
 Some additional fields should be filled in as you get a better understanding of the issue:
 - for a regression, if you identify the fix that caused it add a link to that issue (and add a [regression_]{.jbs-field}*(ID)* label) and set the _Introduced in Release_ field.
@@ -244,7 +244,7 @@ Once the work on an issue has been completed the issue should be in a "closed" s
 </tr>
 <tr>
     <td class="dictionary">[Duplicate]{.jbs-field}</td>
-    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the new issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok</td>
+    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the new issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok. Remember to add a [duplicates]{.jbs-field} link - not a [relates to]{.jbs-field} link</td>
 </tr>
 <tr>
     <td class="dictionary">[Incomplete]{.jbs-field}</td>
@@ -264,7 +264,7 @@ Once the work on an issue has been completed the issue should be in a "closed" s
 </tr>
 <tr>
     <td class="dictionary">[External]{.jbs-field}</td>
-    <td class="dictionary">Use where the issue is due to a problem in a Java library (not shipped with the JDK), an IDE or other external tool etc. where known it is good to provide a link to the site where the issue should be reported.</td>
+    <td class="dictionary">Use where the issue is due to a problem in a Java library (not shipped with the JDK), an IDE or other external tool etc. where known, it is good to provide a link to the site where the issue should be reported.</td>
 </tr>
 <tr>
     <td class="dictionary">[Not an Issue]{.jbs-field}</td>
@@ -661,7 +661,7 @@ Examples:  If a bug fix only corrects a change in the build system, then add the
   <tr>
     <td class="dictionary">[[regression]{.jbs-label}]{#regression}</td>
     <td class="dictionary">
-      Used to identify regressions. A regression is where behavior has _incorrectly_ changed from a previous release. Ideally all regressions must be fixed in the following release. All regressions must have the [Affects Version/s]{.jbs-field} set.
+      Used to identify regressions. A regression is where behavior has _incorrectly_ changed from a previous build or release. Ideally all regressions must be fixed in the following release. All regressions must have the [Affects Version/s]{.jbs-field} set.
     </td>
   </tr>
   <tr>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -20,17 +20,17 @@ When filing an Issue, try to make the report as complete as possible in order to
 
 #### Types of Issues
 
-The most common [Issue]{.jbs-field} types are:
+The most common **Issue** types are:
 <br />
 <table class="dictionary" summary="JBS Issue Types">
 <tr style="text-align:left;"><th>Issue Type</th><th>Covers</th></tr>
 <tr>
     <td class="dictionary">[Bug]{.jbs-field}</td>
-    <td class="dictionary">Used when reporting a problem: crashes; hangs; failures of functionality etc.</td>
+    <td class="dictionary">A "bug" should relate to functional correctness - a deviation from behavior that can be tied back to a specification. Anything else, including performance concerns, is generally not a bug, but an enhancement. Though it is not clear cut as a significant performance regression may be classified as a "bug", for example</td>
 </tr>
 <tr>
     <td class="dictionary">[Enhancement]{.jbs-field}</td>
-    <td class="dictionary">For a small improvement to existing functionality<br />
+    <td class="dictionary">For a small to medium improvement to existing functionality<br />
 </tr>
 <tr>
     <td class="dictionary">[New Feature]{.jbs-field}</td>
@@ -46,10 +46,13 @@ The most common [Issue]{.jbs-field} types are:
 </tr>
 <tr>
     <td class="dictionary">[Task]{.jbs-field}</td>
-    <td class="dictionary">Where something needs to happen other than a code change - for example a request for a new JBS version, or other work associated with a release</td>
+    <td class="dictionary"> Tasks are used to track work that is not expected to result in a change in any code repository. They are used to track non-repo changes or related activities such as a new JBS version number, a build request, an update to a document etc.</td>
 </tr>
 </table>
-Note: If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org), also use this alias if you find an existing report which may be a vulnerability. Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels - see [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.
+Notes:
+
+* If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org), also use this alias if you find an existing report which may be a vulnerability. Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels - see [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.
+* a [Bug]{.jbs} or [Enhancement]{.jbs-field} should only be used if the work is expected to result in a change in a code repository. A [Bug]{.jbs-field} or [Enhancement]{.jbs-field} with resolution Fixed is required to have a corresponding changeset in one of the OpenJDK repositories.
 
 <br>
 A few things to keep in mind when filing an issue to report a problem:
@@ -170,7 +173,9 @@ style ClosedIncomplete fill:lightgreen
 
 ## Triaging an issue
 
-First give the issue a general review
+For the most OpenJDK groups Triage is performed on a regular basis (at least weekly) by triage teams. Each triage team consists of contributors who are area experts for that group of issues. If you haven't been selected to be part of a triage team for a specific area you shouldn't be triaging bugs in that area, unless you are the assignee.
+
+When triaging an issue, first give it a general review
 
 1. If the issue is a duplicate, close it as such.
 1. If the issue belongs to a different area (it was filed in libraries, but it is an HotSpot issue), transfer it to the correct component/subcomponent making sure that the state remains [New]{.jbs-field}.
@@ -188,8 +193,8 @@ Now that the issue is in the right component and has the basic information, the 
     1. a bug should be fixed first in the most recent version where it exists, if you don't know what version it will go into set it to `tbd`
     1. if the bug also exists in older versions it may require backporting
         * the decision to backport should be made inline with the guidelines of the lead for the release
-        * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo.
-    1. Only one fixversion should ever be set, if the issue is to be fixed in additional releases then a separate backport must be created (See Working with backports in JBS).  There are exceptions to this rule for: CSRs; and, Release Notes.
+        * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo (see [Working with backports in JBS](#working-with-backports-in-jbs).
+    1. Only one fixversion should ever be set, if the issue is to be fixed in additional releases then a separate backport must be created (see [Working with backports in JBS](#working-with-backports-in-jbs)).  There are exceptions to this rule for: CSRs; and, Release Notes.
 1. make sure the bug has all the required labels – JBS Label Dictionary
     1. bugs that are new in the current release: 'regression'
     1. bugs that do not affect product code, but are only against the regression test: 'noreg-self'
@@ -197,7 +202,7 @@ Now that the issue is in the right component and has the basic information, the 
     1. RFEs that are pure cleanups: 'noreg-cleanup'
     1. project specific issues usually have their own labels as well
 
-At this point move the issue into the [Open]{.jbs-field} state, bring high priority (P1, P2) bugs to the attention of the team.
+At this point move the issue into the [Open]{.jbs-field} state.
 
 ### Sensitive information (e.g. hs_err.log)
 

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -26,23 +26,23 @@ The most common **Issue** types are:
 <tr style="text-align:left;"><th>Issue Type</th><th>Covers</th></tr>
 <tr>
     <td class="dictionary">[Bug]{.jbs-field}</td>
-    <td class="dictionary">A "bug" should relate to functional correctness - a deviation from behavior that can be tied back to a specification. Anything else, including performance concerns, is generally not a bug, but an enhancement. Though it is not clear cut as a significant performance regression may be classified as a "bug", for example</td>
+    <td class="dictionary">A "bug" should relate to functional correctness - a deviation from behavior that can be tied back to a specification. Anything else, including performance concerns, is generally not a bug, but an enhancement. Though it is not clear cut as a significant performance regression may be classified as a "bug", for example.</td>
 </tr>
 <tr>
     <td class="dictionary">[Enhancement]{.jbs-field}</td>
-    <td class="dictionary">For a small to medium improvement to existing functionality<br />
+    <td class="dictionary">For a small to medium improvement to existing functionality.<br />
 </tr>
 <tr>
     <td class="dictionary">[New Feature]{.jbs-field}</td>
-    <td class="dictionary">Not recommended for use<br /></td>
+    <td class="dictionary">Not recommended for use.<br /></td>
 </tr>
 <tr>
     <td class="dictionary">[JEP]{.jbs-field}</td>
-    <td class="dictionary">For a proposal of a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1)</td>
+    <td class="dictionary">For a proposal of a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1).</td>
 </tr>
 <tr>
     <td class="dictionary">[Sub-task]{.jbs-field}</td>
-    <td class="dictionary">Can be used to break up the work for an issue, such as the changes to the docs, tests etc. This is not recommended as a way to break up a large amount of code change associated with a new feature - see "Implementing a JEP or any Large Change" below</td>
+    <td class="dictionary">Can be used to break up the work for an issue, such as the changes to the docs, tests etc. This is not recommended as a way to break up a large amount of code change associated with a new feature - see "Implementing a JEP or any Large Change" below.</td>
 </tr>
 <tr>
     <td class="dictionary">[Task]{.jbs-field}</td>
@@ -59,15 +59,15 @@ A few things to keep in mind when filing an issue:
 
 * Before filing, verify that there isn't an open issue already filed,
     * Search [JBS](https://bugs.openjdk.org/) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
-    * if you find a similar issue that was closed as "not reproducible" then it may be appropriate to re-open that one - if you don't have direct access to JBS you can file a bug at [bugs.java.com](https://java.bugs.com) requesting that it be reopened.
+    * If you find a similar issue that was closed as "not reproducible" then it may be appropriate to re-open that one - if you don't have direct access to JBS you can file a bug at [bugs.java.com](https://java.bugs.com) requesting that it be reopened.
 * Make a reasonable attempt to narrow down which build or release the failure first appeared in.
 * Add relevant [Labels]{.jbs-field} like [[intermittent]{.jbs-label}](#intermittent), [[regression]{.jbs-label}](#regression), [[noreg-self]{.jbs-label}](#noreg-self), [[tier1]{.jbs-label}](#tier) etc.
-    * For more information see the [JBS Label Dictionary](#jbs-label-dictionary)
+    * For more information see the [JBS Label Dictionary](#jbs-label-dictionary).
 * Set [Affects Version/s]{.jbs-field} to the earliest JDK version(s) where the failure was seen.
     * If the failure is found in an update train of the JDK (e.g. 11.0.x), please make an effort to see if it is also present in [mainline](https://github.com/openjdk/jdk).
 * Set the priority
     * It's not the reporter's responsibility to set a correct priority, but a qualified guess is always better than the default - in JBS the range of priorities go from P1 (High/Important) to P5 (Very Low/Not Important), with the default being P4.
-    *  If you have a sense that the issue is critical, or not critical at all, then adjusting the priority higher or lower makes sense, otherwise leave it as the default.
+    * If you have a sense that the issue is critical, or not critical at all, then adjusting the priority higher or lower makes sense, otherwise leave it as the default.
     * When setting the priority, consider things like how the bug impacts the product and our testing, how likely is it that the bug is triggered, how difficult is it to work around, and whether it's a regression, since that may break existing applications. Regressions are often higher priority than long-standing bugs and may block a release if not fixed. An example of a P1 would be an issue that is blocking a build or a release, whereas a P5 would be a minor typo in a code comment.
 * In the [Description]{.jbs-field}, always include (if possible):
     * error messages
@@ -90,7 +90,7 @@ A few things to keep in mind when filing an issue:
 Things to keep in mind when requesting an improvement:
 
 * Unlike reporting a problem, when it comes to improvements what constitutes a reasonable request can take discussion, and in general it is encouraged that the mailing list for the area is used to suggest an improvement before filing.
-* Enhancements to The Java Language Specification and The JVM Specification are managed through the [Java Community Process](http://jcp.org/)
+* Enhancements to The Java Language Specification and The JVM Specification are managed through the [Java Community Process](http://jcp.org/).
 
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
 
@@ -112,7 +112,7 @@ JBS only has a few states in which an issue can be in:
 </tr>
 <tr>
     <td class="dictionary">[Open]{.jbs-field}</td>
-    <td class="dictionary">Once the issue has been triaged it will be in the [Open]{.jbs-field} state and will stay here until the assignee decides to work on it, at which point it is encouraged that the "Start Work" option be selected to move it to [In Progress]{.jbs-field}</td>
+    <td class="dictionary">Once the issue has been triaged it will be in the [Open]{.jbs-field} state and will stay here until the assignee decides to work on it, at which point it is encouraged that the "Start Work" option be selected to move it to [In Progress]{.jbs-field}.</td>
 </tr>
 <tr>
     <td class="dictionary">[In Progress]{.jbs-field}</td>
@@ -120,7 +120,7 @@ JBS only has a few states in which an issue can be in:
 </tr>
 <tr>
     <td class="dictionary">[Closed]{.jbs-field}/[Resolved]{.jbs-field}</td>
-    <td class="dictionary">While [Closed]{.jbs-field} and [Resolved]{.jbs-field} are essentially equivalent, when it comes to fixing issues there is an additional [Verify]{.jbs-field} step available between the [Resolved]{.jbs-field} and [Closed]{.jbs-field} states</td>
+    <td class="dictionary">While [Closed]{.jbs-field} and [Resolved]{.jbs-field} are essentially equivalent, when it comes to fixing issues there is an additional [Verify]{.jbs-field} step available between the [Resolved]{.jbs-field} and [Closed]{.jbs-field} states.</td>
 </tr>
 </table>
 
@@ -176,7 +176,7 @@ style ClosedIncomplete fill:lightgreen
 
 ## Triaging an issue
 
-For the most OpenJDK groups Triage is performed on a regular basis (at least weekly) by triage teams. Each triage team consists of contributors who are area experts for that group of issues. If you haven't been selected to be part of a triage team for a specific area you shouldn't be triaging bugs in that area.
+For most OpenJDK groups Triage is performed on a regular basis (at least weekly) by triage teams. Each triage team consists of contributors who are area experts for that group of issues. If you haven't been selected to be part of a triage team for a specific area you shouldn't be triaging bugs in that area.
 
 When triaging an issue, first give it a general review
 
@@ -186,24 +186,24 @@ When triaging an issue, first give it a general review
 
 Now that the issue is in the right component and has the basic information, the analysis continues to get a more detailed understanding of the issue, and what should be done:
 
-1. ensure the priority is correct - an approach that has been used for getting a consistent view of priority is to consider three aspects of the issue: [Impact]{.jbs-field} or issue; [Likelihood]{.jbs-field} of it occurring; and, whether there is a [Workaround]{.jbs-field}. The higher the [Impact]{.jbs-field} and [Likelihood]{.jbs-field} the higher the priority; then, having a [Workaround]{.jbs-field} reduces that priority - but mostly where the Impact and Likelihood are not that severe.
-1. ensure the 'Affects Version/s' field is correct (within reason)
-    1. this may involve reproducing the bug, if doing so is fast and easy
+1. Ensure the priority is correct - an approach that has been used for getting a consistent view of priority is to consider three aspects of the issue: [Impact]{.jbs-field} or issue; [Likelihood]{.jbs-field} of it occurring; and, whether there is a [Workaround]{.jbs-field}. The higher the [Impact]{.jbs-field} and [Likelihood]{.jbs-field} the higher the priority; then, having a [Workaround]{.jbs-field} reduces that priority - but mostly where the Impact and Likelihood are not that severe.
+1. Ensure the 'Affects Version/s' field is correct (within reason)
+    1. This may involve reproducing the bug, if doing so is fast and easy.
     1. In addition to the version where the bug was found, take special care to also investigate if the bug affects the supported releases - the latest LTS release and the latest six-month release.
     1. The affects version is not meant to be an exhaustive list of releases the issue is relevant to - it should initially be set to the release the issue was reproduced or identified on, and by implication it will be relevant on all releases past that point (see (Rel)-na label). If it is later found to be applicable to an earlier release family then adding that earlier release is encouraged if the issue needs to be fixed in that release.
     1.  Do not add additional release values to `Affected Versions` for the same release family: if there is the value 11.0.2 do not add 11.0.5, 11.0.7 etc.  Adding an additional value for a separate release family where it is still reproducible, 12 say, is not necessary but ok, especially if the bug is old (reported on 8 say) but still relevant to the latest release (20 say).
-1. set the 'Fix Version'
-    1. a bug should be fixed first in the most recent version where it exists, if you don't know what version it will go into set it to `tbd`
-    1. if the bug also exists in older versions it may require backporting
-        * the decision to backport should be made inline with the guidelines of the lead for the release
-        * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo (see [Working with backports in JBS](#working-with-backports-in-jbs).
+1. Set the 'Fix Version'
+    1. A bug should be fixed first in the most recent version where it exists, if you don't know what version it will go into set it to `tbd`.
+    1. If the bug also exists in older versions it may require backporting
+        * The decision to backport should be made inline with the guidelines of the lead for the release
+        * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo (see [Working with backports in JBS](#working-with-backports-in-jbs)).
     1. Only one fixversion should ever be set, if the issue is to be fixed in additional releases then a separate backport must be created (see [Working with backports in JBS](#working-with-backports-in-jbs)).  There are exceptions to this rule for: CSRs; and, Release Notes.
-1. make sure the bug has all the required labels – see [JBS Label Dictionary](#jbs-label-dictionary)
-    1. bugs where behavior has _incorrectly_ changed from a previous build or release : 'regression'
-    1. bugs that do not affect product code, but are only against the regression test: 'noreg-self'
-    1. issues that seem to be trivial to fix: 'starter'
+1. Make sure the bug has all the required labels – see [JBS Label Dictionary](#jbs-label-dictionary)
+    1. Bugs where behavior has _incorrectly_ changed from a previous build or release : 'regression'
+    1. Bugs that do not affect product code, but are only against the regression test: 'noreg-self'
+    1. Issues that seem to be trivial to fix: 'starter'
     1. RFEs that are pure cleanups: 'noreg-cleanup'
-    1. project specific issues usually have their own labels as well
+    1. Project specific issues usually have their own labels as well
 
 At this point move the issue into the [Open]{.jbs-field} state.
 
@@ -237,33 +237,34 @@ Once the work on an issue has been completed the issue should be in a "closed" s
 <ul>
         <li>Once a bug is marked as fixed there is now the option of someone, other than the person that fixed it, marking it as [Verified]{.jbs-field} to confirm that the issue is fix after testing; marking it as [Fix Failed]{.jbs-field} if it did not solve the issue; or, [Not Verified]{.jbs-field} to indicate that it wasn't explicitly tested.  Note that the UI does not highlight when [Fix Failed]{.jbs-field} has been set, you need to look for the [Verification]{.jbs-label} Field at the bottom of the left-hand colum in the Details section.</li>
 </ul><br />
-    If there is not a fix in the repo (and so no associated changeset) then the issue should not be marked as [Fixed]{.jbs-field}, but set to [Delivered]{.jbs-field}<br />
+    If there is not a fix in the repo (and so no associated changeset) then the issue should not be marked as [Fixed]{.jbs-field}, but set to [Delivered]{.jbs-field}.<br />
     If you know that an issue was fixed, try searching for the issue that resolved it and close it as a duplicate of that issue. If that would entail a significant effort, and/or it isn't a critical issue, close it out as Not Reproducible.<br />
     </td>
 </tr>
 <tr>
     <td class="dictionary">[Won't Fix]{.jbs-field}</td>
-    <td class="dictionary">Used when the issue is describing behavior which, while maybe problematic or not ideal, is not going to be changed - for compatibility reasons for example</td>
+    <td class="dictionary">Used when the issue is describing behavior which, while maybe problematic or not ideal, is not going to be changed - for compatibility reasons for example.</td>
 </tr>
 <tr>
     <td class="dictionary">[Duplicate]{.jbs-field}</td>
-    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the new issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok. Remember to add a [duplicates]{.jbs-field} link - not a [relates to]{.jbs-field} link</td>
+    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the new issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok. <br />
+     Note: if you use "Close" button then you get the UI that allows you to set the Resolution as "Duplicate" and link to the issue which is duplicated. However, if you use "Resolve" then the ability to add the link in the UI is not there, and you need to make sure you remember to manually link in the duplicate issue.</td>
 </tr>
 <tr>
     <td class="dictionary">[Incomplete]{.jbs-field}</td>
-    <td class="dictionary">Described above</td>
+    <td class="dictionary">Described above.</td>
 </tr>
 <tr>
     <td class="dictionary">[Cannot Reproduce]{.jbs-field}</td>
-    <td class="dictionary">Use when a reproducer is provided (or clear steps) but it is not possible to see the same behavior. When you can't reproduce an issue, where feasible try on the release the issue was reported against, as a way of confirming that it is indeed addressed on the latest release, rather than you not having the right environment in which to reproduce the issue</td>
+    <td class="dictionary">Use when a reproducer is provided (or clear steps) but it is not possible to see the same behavior. When you can't reproduce an issue, where feasible try on the release the issue was reported against, as a way of confirming that it is indeed addressed on the latest release, rather than you not having the right environment in which to reproduce the issue.</td>
 </tr>
 <tr>
     <td class="dictionary">[Other]{.jbs-field}</td>
-    <td class="dictionary">Used where none of the other statuses fit the situation</td>
+    <td class="dictionary">Used where none of the other statuses fit the situation.</td>
 </tr>
 <tr>
     <td class="dictionary">[Future Project]{.jbs-field}</td>
-    <td class="dictionary">This status is not recommended</td>
+    <td class="dictionary">This status is not recommended.</td>
 </tr>
 <tr>
     <td class="dictionary">[External]{.jbs-field}</td>
@@ -271,7 +272,7 @@ Once the work on an issue has been completed the issue should be in a "closed" s
 </tr>
 <tr>
     <td class="dictionary">[Not an Issue]{.jbs-field}</td>
-    <td class="dictionary">Use when the behavior is expected and valid (cf. [Won't Fix]{.jbs-field}) and the reporter perhaps has misunderstood what the behavior should be</td>
+    <td class="dictionary">Use when the behavior is expected and valid (cf. [Won't Fix]{.jbs-field}) and the reporter perhaps has misunderstood what the behavior should be.</td>
 </tr>
 <tr>
     <td class="dictionary">[Migrated]{.jbs-field}</td>
@@ -279,23 +280,23 @@ Once the work on an issue has been completed the issue should be in a "closed" s
 </tr>
 <tr>
     <td class="dictionary">[Rejected]{.jbs-field}</td>
-    <td class="dictionary">This status should not be used</td>
+    <td class="dictionary">This status should not be used.</td>
 </tr>
 <tr>
     <td class="dictionary">[Withdrawn]{.jbs-field}</td>
-    <td class="dictionary">Is essentially the partner state to Delivered for issues that would not have resulted in a fix to the repo, and also part of the [CSR](https://wiki.openjdk.org/display/csr/Main) and Release Note process</td>
+    <td class="dictionary">Is essentially the partner state to Delivered for issues that would not have resulted in a fix to the repo, and also part of the [CSR](https://wiki.openjdk.org/display/csr/Main) and Release Note process.</td>
 </tr>
 <tr>
     <td class="dictionary">[Delivered]{.jbs-field}</td>
-    <td class="dictionary">Use to close out issues where a change to the code is not required, common examples are Release Notes</td>
+    <td class="dictionary">Use to close out issues where a change to the code is not required, common examples are Release Notes.</td>
 </tr>
 <tr>
     <td class="dictionary">[Approved]{.jbs-field}</td>
-    <td class="dictionary">Used as part of the [CSR process](https://wiki.openjdk.org/display/csr/Main)
+    <td class="dictionary">Used as part of the [CSR process](https://wiki.openjdk.org/display/csr/Main).
 </tr>
 <tr>
     <td class="dictionary">Challenge States</td>
-    <td class="dictionary">[Exclude [Challenge]]{.jbs-field}, [Alternative Tests [Challenge]]{.jbs-field}, and [Reject [Challenge]]{.jbs-field} are only relevant within the context of the JCK Project</td>
+    <td class="dictionary">[Exclude [Challenge]]{.jbs-field}, [Alternative Tests [Challenge]]{.jbs-field}, and [Reject [Challenge]]{.jbs-field} are only relevant within the context of the JCK Project.</td>
 </tr>
 </table>
 

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -5,42 +5,197 @@
 
 * [Bug Report Tool](https://bugreport.java.com/)
 * [JDK Bug System (JBS)](https://bugs.openjdk.org/)
-:::
+  :::
 
-[JBS](https://bugs.openjdk.org/) is a public issue tracker used by many OpenJDK projects. It's open for anyone to read and search. In order to get write access you need to be registered in the [OpenJDK Census](https://openjdk.org/census), for instance by becoming an [Author](https://openjdk.org/bylaws#author) in an OpenJDK [Project](https://openjdk.org/bylaws#project).
+[JBS](https://bugs.openjdk.org/) is a public issue tracker used by many OpenJDK projects and is open for anyone to read and search. In order to get write access you need to be registered in the [OpenJDK Census](https://openjdk.org/census) by becoming, for instance, an [Author](https://openjdk.org/bylaws#author) in an OpenJDK [Project](https://openjdk.org/bylaws#project).
 
-## Filing a bug
+## Filing an issue
 
-When a new failure is found in the JDK a bug should be filed to describe and track the issue. Depending on your role in OpenJDK you can either use the [Bug Report Tool](https://bugreport.java.com/) or, if you are registered in the [OpenJDK Census](https://openjdk.org/census), report the bug directly in [JBS](https://bugs.openjdk.org/). Try to make the bug report as complete as possible to make it easier to triage and investigate the bug.
+When a new failure is found, or an improvement identified, an issue should be filed to describe and track its resolution.
+Depending on your role in OpenJDK you can either use the [Bug Report Tool](https://bugreport.java.com/) or, if you
+are registered in the [OpenJDK Census](https://openjdk.org/census), you can report the issue directly in [JBS](https://bugs.
+openjdk.org/).
 
-A few things to keep in mind when filing a new bug:
+When filing an Issue, try to make the report as complete as possible in order to make it easier to triage, investigate and resolve the issue.
 
-* Before filing a bug, verify that there isn't already a bug filed for this issue.
-  * Search [JBS](https://bugs.openjdk.org/) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
-* If you suspect that the bug is a vulnerability, **don't file a JBS issue**. Instead send your bug report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org).
-  * Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels.
-  * See [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.
+#### Types of Issues
+
+The most common Issue types are:
+<br />
+<table class="dictionary" summary="JBS Label Dictionary">
+  <tr style="text-align:left;"><th>Type</th><th>Covers</th></tr>
+<tr>
+    <td class="dictionary">[Bug]{.jbs-field}</td>
+    <td class="dictionary">Used when reporting a problem: crashes; hangs; failures of functionality etc.</td>
+</tr>
+<tr>
+    <td class="dictionary"><i>Improvement</i></td>
+    <td class="dictionary">When requesting an improvement in the JDK, the issue type used depends on the size/scope of the improvement:<br />
+    ([Enhancement]{.jbs-field}) - for a small improvement to existing functionality<br />
+    ([New Feature]{.jbs-field}) - not recommended to use<br />
+([JEP]{.jbs-field}) - for a proposal for a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1)</td>
+</tr>
+<tr>
+    <td class="dictionary">[Sub-task]{.jbs-field}</td>
+    <td class="dictionary">Can be used to break up the work for an issue, such as the changes to the docs, tests etc. This is not recommended as a way to break up a large amount of code change associated with a new feature - see "Implementing a JEP or any Large Change" below</td>
+</tr>
+<tr>
+    <td class="dictionary">[Task]{.jbs-field}</td>
+    <td class="dictionary">Where something needs to happen other than a code change - a request for a new JBS version value for example</td>
+</tr>
+<tr>
+    <td class="dictionary"><i>Vulnerability</i></td>
+    <td class="dictionary">If you suspect that the issue is a vulnerability, **don't file a JBS issue**, instead send your report to [vuln-report@openjdk.org](mailto:vuln-report@openjdk.org). <br>Please do *not* report or discuss potential vulnerabilities on any open lists or other public channels. <br>See [OpenJDK Vulnerabilities](https://openjdk.org/groups/vulnerability/report) for more information.</td>
+</tr>
+</table>
+
+<br>
+A few things to keep in mind when filing an issue to report a problem:
+
+* Before filing, verify that there isn't an issue already filed.
+    * Search [JBS](https://bugs.openjdk.org/) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
 * Make a reasonable attempt to narrow down which build or release the failure first appeared in.
 * Add relevant [Labels]{.jbs-field} like [[intermittent]{.jbs-label}](#intermittent), [[regression]{.jbs-label}](#regression), [[noreg-self]{.jbs-label}](#noreg-self), [[tier1]{.jbs-label}](#tier) etc.
-  * To find relevant labels see the [JBS Label Dictionary](#jbs-label-dictionary)
-* Set [Affects Version/s]{.jbs-field} to the JDK version(s) where the failure was seen.
-  * If the failure is found in an update train of the JDK (e.g. 11.0.x), please make an effort to see if the bug is also present in [mainline](https://github.com/openjdk/jdk).
-* Set priority
-  * It's not the reporter's responsibility to set a correct priority, but a qualified guess is always better than a default value.
-  * To help with setting the right priority consider things like how the bug impacts the product and our testing, how likely is it that the bug triggers, how difficult is it to work around the bug if it's not fixed soon, and whether it's a regression, since that may break existing applications. Regressions are often higher priority than long standing bugs and may block a release if not fixed.
+    * For more information see the [JBS Label Dictionary](#jbs-label-dictionary)
+* Set [Affects Version/s]{.jbs-field} to the earliest JDK version(s) where the failure was seen.
+    * If the failure is found in an update train of the JDK (e.g. 11.0.x), please make an effort to see if it is also present in [mainline](https://github.com/openjdk/jdk).
+* Set the priority
+    * It's not the reporter's responsibility to set a correct priority, but a qualified guess is always better than the default.
+    * To help with setting the right priority, consider things like how the bug impacts the product and our testing, how likely is it that the bug is triggered, how difficult is it to work around, and whether it's a regression, since that may break existing applications. Regressions are often higher priority than long-standing bugs and may block a release if not fixed. An example of a P1 would be an issue that is blocking a build or a release, whereas a P5 would be a minor typo in a code comment - most bugs will be P3 or P4.
 * In the [Description]{.jbs-field}, always include (if possible):
-  * full name of the failing tests
-  * error messages
-  * assert messages
-  * stack trace
-  * command line information
-  * relevant information from the logs
-* If the failure isn't reproducible with an existing OpenJDK test, attach a reproducer if possible.
-* Only set [CPU]{.jbs-field} and/or [OS]{.jbs-field} fields if the bug **ONLY** happens on that particular platform.
+    * error messages
+    * assert messages
+    * stack trace
+    * command line information
+    * relevant information from the logs
+    * full name of any failing tests
+* Avoid including in the description or comments:
+    * personal information
+    * passwords, logins, machine names
+    * logs which may include sensitive data
+* If the failure isn't reproducible with an existing OpenJDK test, attach a reproducer if possible, while in a number of cases it isn't possible, having a test case will decrease the time required to resolve the issue.
+* Only set [CPU]{.jbs-field} and/or [OS]{.jbs-field} fields if the bug **ONLY** happens on that particular platform or set of platforms.
+* Including the java -fullversion is encouraged for bugs in the JVM, hangs, network issues where the exact version can be critical to determine what fixes may be missing from an older version.
 * Always file separate bugs for different issues.
-  * If two crashes looks related but not similar enough to for sure be the same, it's easier to close a bug as a duplicate than it is to extract the relevant info from a bug to create a new one later.
+    * If two crashes looks related, but not similar enough to be sure they are the same, it's easier to later close a bug as a duplicate than it is to separate out one bug into two.
+
+Things to keep in mind when requesting an improvement:
+
+* Unlike reporting a problem, when it comes to improvements what constitutes a reasonable request can take discussion, and in general it is encouraged that the mailing list for the area is used to suggest an improvement before filing.
+* Enhancements to The Java Language Specification and The JVM Specification are managed through the [Java Community Process](http://jcp.org/)
 
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
+
+### Implementing a Large Change
+When managing the work for a large change, especially when the work involves multiple engineers, it is recommended that the work is distributed across one or more "implementation" issues which should be linked to the main [Enhancement]{.jbs-field} with a "blocks" link along with any relevant CSRs. The [Enhancement]{.jbs-field} should not be considered done until all the blocking element are completed.  The use of subTasks for [Enhancement]{.jbs}s is not recommended unless all the [Sub-task]{.jbs-field}s are relevant to the fix, if it were to be backported.
+
+### Implementing a JEP
+It recommended that for [JEP]{.jbs-field}s the implementation is spread across one or more [Enhancement]{.jbs-field}s as above.
+
+## Issue states
+
+JBS only has a few states in which an issue can be in:
+
+<table class="dictionary" summary="JBS Label Dictionary">
+  <tr style="text-align:left;"><th>Type</th><th>Covers</th></tr>
+<tr>
+    <td class="dictionary">[New]{.jbs-field}</td>
+    <td class="dictionary">Initial state after an issue is filed. [Bugs]{.jbs-field} in the JDK Project must be taken out of the [New]{.jbs-field} state (Triaged - see below) in a timely manner. In general, this is recommended to be done for all issue types and projects as a sign that the issue is correctly filed, and will be seen by the right group - this is especially important towards the end of a release.</td>
+</tr>
+<tr>
+    <td class="dictionary">Open</td>
+    <td class="dictionary">Most straightforward issues stay in this state until they are closed.  If the issue has some attention then use "In Progress" to show more clearly that the issue is being worked</td>
+</tr>
+<tr>
+    <td class="dictionary">In Progress</td>
+    <td class="dictionary">The <i>In Progress</i> state has the option of the sub-states ([Understanding]{.jbs-field}): [Cause Known]{.jbs-field}, [Fix Understood]{.jbs-field}, [In Review]{.jbs-field}.</td>
+</tr>
+<tr>
+    <td class="dictionary">Closed/Resolved</td>
+    <td class="dictionary">While [Closed]{.jbs-field} and [Resolved]{.jbs-field} are essentially equivalent, when it comes to fixing issues there is an additional [Verify]{.jbs-field} step available between the [Resolved]{.jbs-field} and [Closed]{.jbs-field} states</td>
+</tr>
+</table>
+
+::: {style="text-align:center;"}
+~~~{.mermaid caption="JBS Issue Flow" format=svg theme=neutral}
+flowchart TD
+
+subgraph top[" "]
+
+New
+triage
+ResolvedIncomplete
+ClosedIncomplete
+Open
+InProgress
+states
+Resolved
+Verify
+Closed
+
+  New(NEW) --> triage
+  Open --> |Move to new component|New
+
+  triage --> |sync with submitter|ResolvedIncomplete(<font color=white>RESOLVED:Incomplete)
+  ResolvedIncomplete --> |Clarified|triage
+  ResolvedIncomplete --> |Not Clarified|ClosedIncomplete
+  ClosedIncomplete(<font color=green>CLOSED:Incomplete) --> Closed
+
+  triage --> Open(OPEN)
+  Open --> states
+
+  Open <--> InProgress(<font color=blue>IN PROGRESS)
+  InProgress --> states
+
+  states(Fixed, Won't Fix, Duplicate etc.) --> Closed
+  states --> Resolved
+  Resolved[<font color=white>RESOLVED] -.-> Verify(Verify)
+  Verify --> Closed(<font color=green>CLOSED)
+end
+
+style top fill:white
+style New fill:lightgrey
+style Open fill:lightgrey
+style triage fill:white
+style states fill:white
+style Verify fill:white
+style Resolved fill:green
+style ResolvedIncomplete fill:green
+style Closed fill:lightgreen
+style ClosedIncomplete fill:lightgreen
+~~~
+:::
+
+## Triaging an issue
+
+First give the issue a general [Review]{.jbs-field}
+
+1. If the issue is a duplicate, close it as such.
+1. If the issue belongs to a different area (it was filed in libraries, but it is an HotSpot issue), transfer it to the correct component/subcomponent making sure that the state remains [New]{.jbs-field}.
+1. If the issue is incomplete, add a comment noting what is needed and close the bug as [Resolved]{.jbs-field} - 'Incomplete'. If no more information is obtained within reasonable time, the issue should be closed (`Closed - Incomplete`).
+
+Now that the issue is in the right component and has the basic information, the analysis continues to get a more detailed understanding of the issue, and what should be done:
+
+1. ensure the priority is correct - an approach that has been used for getting a consistent view of priority is to consider three aspects of the issue: [Impact]{.jbs-field} or issue; [Likelihood]{.jbs-field} of it occurring; and, whether there is a [Workaround]{.jbs-field}. The higher the [Impact]{.jbs-field} and [Likelihood]{.jbs-field} the higher the priority; then, having a [Workaround]{.jbs-field} reduces that priority - but mostly where the Impact and Likelihood are not that severe.
+1. ensure the 'Affects Version/s' field is correct (within reason)
+    1. this may involve reproducing the bug, if doing so is fast and easy
+    1. In addition to the version where the bug was found, take special care to also investigate if the bug affects the supported releases - the latest LTS release and the latest six-month release.
+    1. The affects version is not meant to be an exhaustive list of releases the issue is relevant to - it should initially be set to the release the issue was reproduced or identified on, and by implication it will be relevant on all releases past that point (see (Rel)-na label). If it is later found to be applicable to an earlier release family then adding that earlier release is encouraged if the issue needs to be fixed in that release.
+    1.  Do not add additional release values to `Affected Versions` for the same release family: if there is the value 11.0.2 do not add 11.0.5, 11.0.7 etc.  Adding an additional value for a separate release family where it is still reproducible, 12 say, is not necessary but ok, especially if the bug is old (reported on 8 say) but still relevant to the latest release (20 say).
+1. set the 'Fix Version'
+    1. a bug should be fixed first in the most recent version where it exists, if you don't know what version it will go into set it to `tbd`
+    1. if the bug also exists in older versions it may require backporting
+        * the decision to backport should be made inline with the guidelines of the lead for the release
+        * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo.
+    1. Only one fixversion should ever be set, if the issue is to be fixed in additional releases then a separate backport must be created (See Working with backports in JBS).  There are exceptions to this rule for: CSRs; and, Release Notes.
+1. make sure the bug has all the required labels – JBS Label Dictionary
+    1. bugs that are new in the current release: 'regression'
+    1. bugs that do not affect product code, but are only against the regression test: 'noreg-self'
+    1. issues that seem to be trivial to fix: 'starter'
+    1. RFEs that are pure cleanups: 'noreg-cleanup'
+    1. project specific issues usually have their own labels as well
+
+At this point move the issue into the [Open]{.jbs-field} state, bring high priority (P1, P2) bugs to the attention of the team.
 
 ### Sensitive information (e.g. hs_err.log)
 
@@ -48,9 +203,92 @@ It may sound obvious, but avoid placing sensitive information in bug reports. Th
 
 If you file a bug through the [Bug Report Tool](https://bugreport.java.com/) there's a specific field that should be used to place sensitive information like this. Information placed there will not be part of the public bug report.
 
-## Resolved - Incomplete
+## Updating an issue while fixing
 
-To resolve an issue as `Incomplete` is JBS lingo for "Need More Information". An issue that is `Resolved - Incomplete` is *not* closed but more information is needed to be able to work on it. If no more information is obtained within reasonable time the issue should be closed (`Closed - Incomplete`). Closing a resolved issue is done using the `Verify` option.
+Once you are made, or you make yourself, the assignee of an Issue you take on the responsibility of moving the issue through to resolution and providing the current status, and ultimately leaving a record for others in the future to understand what happened.  There are no real rules for how you manage the bug while you are assigned to it, as it depends on the type and importance of an issue.  A simple update to the doc needs little to be done, fix the problem and close the issue; an intricate timing issue or crash should be handled differently - documenting your progress in identifying the problem (for example
+[JDK-8212207](https://bugs.openjdk.org/browse/JDK-8212207),
+[JDK-6984895](https://bugs.openjdk.org/browse/JDK-6984895),
+[JDK-8287982](https://bugs.openjdk.org/browse/JDK-8287982)
+), this is especially helpful if you ultimately move the Issue to a different area as you have found that the problem lies elsewhere or is closed as [Will Not Fix]{.jbs-field}.  Your updates can provide a resource to others to better understand the code. See [The Importance of Writing Stuff Down](https://stuartmarks.wordpress.com/2023/02/22/the-importance-of-writing-stuff-down) for a good explanation as to why it is also important to write an evaluation when something is not fixed.
+
+
+Some additional fields should be filled in as you get a better understanding of the issue:
+- for a regression, if you identify the fix that caused it add a link to that issue (and add a [regression_]{.jbs-field}*(ID)* label) and set the _Introduced in Release_ field.
+- The description usually explains what went wrong and how the failure was found, then there's some investigation and eventually the root cause is found. At this point the Summary should be updated to correctly describe the bug. The Description however should remain a description of how the failure was found.
+
+## Resolving an issue
+
+Once the work on an issue has been completed this should be indicated in JBS by moving the issue to a "closed" state.  There are two "closed" states: [Resolved]{.jbs-field} and [Closed]{.jbs-field} which can be used interchangeably except in the case of [Fixed]{.jbs-field}, or when flagged as  [Incomplete]{.jbs-field} (See Triaging).
+
+<table class="dictionary" summary="JBS Label Dictionary">
+  <tr style="text-align:left;"><th>Type</th><th>Covers</th></tr>
+<tr>
+    <td class="dictionary">[Fixed]{.jbs-field}</td>
+    <td class="dictionary">If a change is required in a repo to address an issue then the [Fixed]{.jbs-field} status should be used - for the JDK project in almost all cases the bots will transition the issue to [Fixed]{.jbs-field} when the changeset is pushed to the repo.<br />
+<ul>
+        <li>Once a bug is marked as fixed there is now the option of someone, other than the person that fixed it, marking it as [Verified]{.jbs-field} to confirm that the issue is fix after testing; marking it as [Fix Failed]{.jbs-field} if it did not solve the issue; or, [Not Verified]{.jbs-field} to indicate that it wasn't explicitly tested.  Note that the UI does not highlight when [Fix Failed]{.jbs-field} has been set, you need to look for the [Verification]{.jbs-label} Field at the bottom of the left-hand colum in the Details section.</li>
+</ul><br />
+    If there is not a fix in the repo (and so no associated changeset) then the issue should not be marked as [Fixed]{.jbs-field}, but set to [Delivered]{.jbs-field}<br />
+    If you know that an issue was fixed, try searching for the issue that resolved it and close it as a duplicate of that issue. If that would entail a significant effort, and/or it isn't a critical issue, close it out as Not Reproducible.<br />
+    </td>
+</tr>
+<tr>
+    <td class="dictionary">[Won't Fix]{.jbs-field}</td>
+    <td class="dictionary">Used when the issue is describing behavior which, while maybe problematic or not ideal, is not going to be changed - for compatibility reasons for example</td>
+</tr>
+<tr>
+    <td class="dictionary">[Duplicate]{.jbs-field}</td>
+    <td class="dictionary">Where the same issue is described in another issue then close one against the other as a [Duplicate]{.jbs-field}. In general the new issue is closed as a duplicate of the older one, but where the newer issue has a clearer description then doing it the other way round is ok</td>
+</tr>
+<tr>
+    <td class="dictionary">[Incomplete]{.jbs-field}</td>
+    <td class="dictionary">Described above</td>
+</tr>
+<tr>
+    <td class="dictionary">[Cannot Reproduce]{.jbs-field}</td>
+    <td class="dictionary">Use when a reproducer is provided (or clear steps) but it is not possible to see the same behavior. Where feasible try on the release the issue was reported against, as a way of confirming that it is indeed addressed, rather than you not having the right environment in which to reproduce the issue</td>
+</tr>
+<tr>
+    <td class="dictionary">[Other]{.jbs-field}</td>
+    <td class="dictionary">Used where none of the other statuses fit the situation</td>
+</tr>
+<tr>
+    <td class="dictionary">[Future Project]{.jbs-field}</td>
+    <td class="dictionary"></td>
+</tr>
+<tr>
+    <td class="dictionary">[External]{.jbs-field}</td>
+    <td class="dictionary">Use where the issue is due to a problem in a Java library (not shipped with the JDK) or an IDE or other external tool</td>
+</tr>
+<tr>
+    <td class="dictionary">[Not an Issue]{.jbs-field}</td>
+    <td class="dictionary">Use when the behavior is expected and valid (cf. [Won't Fix]{.jbs-field}) and the reporter perhaps has misunderstood what the behavior should be</td>
+</tr>
+<tr>
+    <td class="dictionary">[Migrated]{.jbs-field}</td>
+    <td class="dictionary">Used rarely, but can be seen when issues are transferred into another Project by opening up a separate issue in that Project, with the issue in the original Project being [Closed]{.jbs-field}</td>
+</tr>
+<tr>
+    <td class="dictionary">[Rejected]{.jbs-field}</td>
+    <td class="dictionary">This status should not be used</td>
+</tr>
+<tr>
+    <td class="dictionary">[Withdrawn]{.jbs-field}</td>
+    <td class="dictionary">Is essentially the partner state to Delivered for issues that would not have resulted in a fix to the repo, and also part of the [CSR](https://wiki.openjdk.org/display/csr/Main) and Release Note process</td>
+</tr>
+<tr>
+    <td class="dictionary">[Delivered]{.jbs-field}</td>
+    <td class="dictionary">Use to close out issues where a changeset is not produced, common examples are Release Notes</td>
+</tr>
+<tr>
+    <td class="dictionary">[Approved]{.jbs-field}</td>
+    <td class="dictionary">Used as part of the [CSR process](https://wiki.openjdk.org/display/csr/Main)
+</tr>
+<tr>
+    <td class="dictionary">Challenge States</td>
+    <td class="dictionary">[Exclude [Challenge]]{.jbs-field}, [Alternative Tests [Challenge]]{.jbs-field}, and [Reject [Challenge]]{.jbs-field} are only relevant within the context of the JCK Project</td>
+</tr>
+</table>
 
 ## JBS labels
 
@@ -61,13 +299,13 @@ JBS labels should not be used to write documentation - don't try to write senten
 > ---
 >
 > ### Labels are case sensitive
-> When using labels in Jira gadgets (like pie charts, heat maps, and statistics tables) Jira will be case sensitive and treat e.g. OpenJDK and openjdk as two different labels. Searching however is case insensitive. This means that if you group a set of issues in a gadget based on a label, and then click one of the groups to see the list of issues, that list will contain more results than the gadget if there are usages of the label with different casing. This can be very confusing and for this reason the recommendation is to stick with the commonly used case for all labels, regardless of your personal taste for upper or lower case letters. Most labels are lower case only, but there are examples where upper case letters are used in the most common version of a label. Use of the autocomplete popup window (described above) when adding labels will avoid inadvertent introduction of labels with differing case.
+> When using labels in Jira gadgets (like pie charts, heat maps, and statistics tables) Jira will be case-sensitive and treat e.g. OpenJDK and openjdk as two different labels. Searching however is case-insensitive. This means that if you group a set of issues in a gadget based on a label, and then click one of the groups to see the list of issues, that list will contain more results than the gadget if there are usages of the label with different casing. This can be very confusing and for this reason the recommendation is to stick with the commonly used case for all labels, regardless of your personal taste for upper or lower case letters. Most labels are lower case only, but there are examples where upper case letters are used in the most common version of a label. Use of the autocomplete popup window (described above) when adding labels will avoid inadvertent introduction of labels with differing case.
 >
 > ---
 
 ## JBS label dictionary
 
-This table contains some frequently used JBS labels and their meaning. Please help keeping this dictionary up to date by adding your favorite labels. This table doesn’t dictate how to use labels, but rather document how they are used. That said, obviously it will help everyone if we try to follow a common standard and use similar labels in the same way across all entities that use JBS.
+This table contains some frequently used JBS labels and their meaning. Please help keeping this dictionary up to date by adding your favorite labels. This table doesn't dictate how to use labels, but rather document how they are used. That said, obviously it will help everyone if we try to follow a common standard and use similar labels in the same way across all entities that use JBS.
 
 <table class="dictionary" summary="JBS Label Dictionary">
   <tr style="text-align:left;"><th>Label</th><th>Description</th></tr>
@@ -148,7 +386,7 @@ This table contains some frequently used JBS labels and their meaning. Please he
   <tr>
     <td class="dictionary">[*(Rel)*[-na]{.jbs-label}]{#rel-na}</td>
     <td class="dictionary">
-      Used to indicate that the issue doesn't affect release *(Rel)* or later. Could for instance be a bug in code that was removed in *(Rel)*. Note that there should only be **one** *(Rel)*[-na]{.jbs-label} label on any JBS issue. The [Affects Version/s]{.jbs-field} field is used to indicate the releases where the issue has been seen.
+      The [Affects Version/s]{.jbs-field} field is used to indicate the releases where an issue has been seen - it is implied that the issue is also applicable to newer releases. Where this is not the case - for instance a bug in code that was removed in *(Rel)* - then use the *(Rel)-na* to indicate this. Note that there should only be **one** *(Rel)*[-na]{.jbs-label} label on any JBS issue. 
     </td>
   </tr>
   <!-- Team -->
@@ -329,7 +567,7 @@ There are other cases as well and there is some flexibility in the definition. I
 If you have a [maintainer-pain]{.jbs-label} bug assigned to you please consider fixing it asap. If you chose not to work on the issue, you should at least be aware that you are choosing to waste others' time and people will be affected by this choice.
 
 As with any issue the best way to deal with a [maintainer-pain]{.jbs-label} issue is to fix it. Another way to reduce the noise is to [exclude the failing test](#excluding-a-test). This is a viable option if there is a limited set of tests that are failing and the bug is actively investigated. When excluding a [maintainer-pain]{.jbs-label} issue, remember to move the [maintainer-pain]{.jbs-label} label to the JBS issue used to exclude. Leaving the label on the closed exclude-issue is helpful for tracking purposes.
-    </td>
+</td>
   </tr>
   <!-- N -->
   <tr>
@@ -369,7 +607,7 @@ As with any issue the best way to deal with a [maintainer-pain]{.jbs-label} issu
 :    It's too hard to write a regression or unit test for this bug (e.g., theoretical race condition, complex setup, reboot required, editing of installed files required, specific graphics card required); the bug should explain why.
 
 [[-long]{.jbs-label}]{#noreg-long}
-:    Testing requires a very long running time (e.g., more than a few minutes).
+:    Testing requires a very long running-time (e.g., more than a few minutes).
 
 [[-big]{.jbs-label}]{#noreg-big}
 :    Testing requires an unreasonable quantity of resources (e.g., tens of gigabytes of filesystem space).
@@ -390,7 +628,7 @@ As with any issue the best way to deal with a [maintainer-pain]{.jbs-label} issu
 :    Regression or unit test is unnecessary or infeasible for some other reason; the bug report should explain why.
 
 Examples:  If a bug fix only corrects a change in the build system, then add the [noreg-build]{.jbs-label} label to the corresponding bug. If the change improves loop optimizations in HotSpot, then add [nounit-perf]{.jbs-label} to the corresponding bug.
-    </td>
+</td>
   </tr>
   <!-- O -->
   <!-- P -->
@@ -409,7 +647,7 @@ Examples:  If a bug fix only corrects a change in the build system, then add the
   <tr>
     <td class="dictionary">[[problemlist]{.jbs-label}]{#problemlist}</td>
     <td class="dictionary">
-      One or more tests has been problemlisted due to this bug.
+      One or more tests has been problem-listed due to this bug.
     </td>
   </tr>
   <!-- Q -->
@@ -418,6 +656,12 @@ Examples:  If a bug fix only corrects a change in the build system, then add the
     <td class="dictionary">[[regression]{.jbs-label}]{#regression}</td>
     <td class="dictionary">
       Used to identify regressions. A regression is a bug that didn't exist in the previous release. Ideally all regressions must be fixed in the following release. All regressions must have the [Affects Version/s]{.jbs-field} set.
+    </td>
+  </tr>
+  <tr>
+    <td class="dictionary">[[regression_]{.jbs-label}*(ID)*]{#regressionId}</td>
+    <td class="dictionary">
+      Used to identify the fix that caused the regression, where known.
     </td>
   </tr>
   <tr>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -91,8 +91,8 @@ Things to keep in mind when requesting an improvement:
 
 To find out which component to use for different bugs, consult the [directory to area mapping](#directory-to-area-mapping).
 
-### Implementing a Large Change
-When managing the work for a large change, especially when the work involves multiple engineers, it is recommended that the work is distributed across one or more "implementation" issues which should be linked to the main [Enhancement]{.jbs-field} with a "blocks" link along with any relevant CSRs. The [Enhancement]{.jbs-field} should not be considered done until all the blocking elements are completed.  The use of subTasks for [Enhancement]{.jbs}s is not recommended unless all the [Sub-task]{.jbs-field}s are relevant to the fix, if it were to be backported.
+### Implementing a large change
+When managing the work for a large change, especially when the work involves multiple engineers, it is recommended that the work is distributed across one or more "implementation" issues which should be linked to the main [Enhancement]{.jbs-field} with a "blocks" link along with any relevant CSRs. The [Enhancement]{.jbs-field} should not be considered done until all the blocking elements are completed.  The use of subTasks for [Enhancement]{.jbs}s is not recommended unless all the [Sub-task]{.jbs-field}s are relevant to the fix, if it were to be backported, for example [JDK-8231641](https://bugs.openjdk.org/browse/JDK-8231641) or [JDK-8171407](https://bugs.openjdk.org/browse/JDK-8171407),
 
 ### Implementing a JEP
 It recommended that for [JEP]{.jbs-field}s that the implementation is spread across one or more [Enhancement]{.jbs-field}s as above.

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -195,8 +195,8 @@ Now that the issue is in the right component and has the basic information, the 
         * the decision to backport should be made inline with the guidelines of the lead for the release
         * There are two options for creating backport issue(s) to track the backport: one is to create it manually once it is agreed that the bug should be backported; the second, is to let the bots create the backport issue once you push the fix to the repo (see [Working with backports in JBS](#working-with-backports-in-jbs).
     1. Only one fixversion should ever be set, if the issue is to be fixed in additional releases then a separate backport must be created (see [Working with backports in JBS](#working-with-backports-in-jbs)).  There are exceptions to this rule for: CSRs; and, Release Notes.
-1. make sure the bug has all the required labels – JBS Label Dictionary
-    1. bugs that are new in the current release: 'regression'
+1. make sure the bug has all the required labels – see [JBS Label Dictionary](#jbs-label-dictionary)
+    1. bugs where behavior has _incorrectly_ changed from a previous release : 'regression'
     1. bugs that do not affect product code, but are only against the regression test: 'noreg-self'
     1. issues that seem to be trivial to fix: 'starter'
     1. RFEs that are pure cleanups: 'noreg-cleanup'
@@ -661,7 +661,7 @@ Examples:  If a bug fix only corrects a change in the build system, then add the
   <tr>
     <td class="dictionary">[[regression]{.jbs-label}]{#regression}</td>
     <td class="dictionary">
-      Used to identify regressions. A regression is a bug that didn't exist in the previous release. Ideally all regressions must be fixed in the following release. All regressions must have the [Affects Version/s]{.jbs-field} set.
+      Used to identify regressions. A regression is where behavior has _incorrectly_ changed from a previous release. Ideally all regressions must be fixed in the following release. All regressions must have the [Affects Version/s]{.jbs-field} set.
     </td>
   </tr>
   <tr>

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -202,7 +202,7 @@ Now that the issue is in the right component and has the basic information, the 
     1. Bugs where behavior has _incorrectly_ changed from a previous build or release : 'regression'
     1. Bugs that do not affect product code, but are only against the regression test: 'noreg-self'
     1. Issues that seem to be trivial to fix: 'starter'
-    1. Enhancements that are pure cleanups: 'noreg-cleanup'
+    1. Enhancements that are pure cleanups: 'cleanup'
     1. Project specific issues usually have their own labels as well
 
 At this point move the issue into the [Open]{.jbs-field} state.

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -7,7 +7,7 @@
 * [JDK Bug System (JBS)](https://bugs.openjdk.org/)
   :::
 
-[JBS](https://bugs.openjdk.org/) is a public issue tracker used by many OpenJDK projects and is open for anyone to read and search. In order to get write access you need to be registered in the [OpenJDK Census](https://openjdk.org/census) by becoming, for instance, an [Author](https://openjdk.org/bylaws#author) in an OpenJDK [Project](https://openjdk.org/bylaws#project).
+[JBS](https://bugs.openjdk.org/) is a public issue tracker used by many OpenJDK projects and is open for anyone to read and search. To get write access you need to be registered in the [OpenJDK Census](https://openjdk.org/census) by becoming, for instance, an [Author](https://openjdk.org/bylaws#author) in an OpenJDK [Project](https://openjdk.org/bylaws#project).
 
 ## Filing an issue
 
@@ -34,11 +34,11 @@ The most common **Issue** types are:
 </tr>
 <tr>
     <td class="dictionary">[New Feature]{.jbs-field}</td>
-    <td class="dictionary">Not recommended to use<br /></td>
+    <td class="dictionary">Not recommended for use<br /></td>
 </tr>
 <tr>
     <td class="dictionary">[JEP]{.jbs-field}</td>
-    <td class="dictionary">For a proposal for a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1)</td>
+    <td class="dictionary">For a proposal of a significant change or new feature which will take 4 weeks or more of work - see [JEP-1](https://openjdk.org/jeps/1)</td>
 </tr>
 <tr>
     <td class="dictionary">[Sub-task]{.jbs-field}</td>
@@ -80,9 +80,9 @@ A few things to keep in mind when filing an issue to report a problem:
     * logs which may include sensitive data
 * If the failure isn't reproducible with an existing OpenJDK test, attach a reproducer if possible, while in a number of cases it isn't possible, having a test case will decrease the time required to resolve the issue.
 * Only set [CPU]{.jbs-field} and/or [OS]{.jbs-field} fields if the bug **ONLY** happens on that particular platform or set of platforms.
-* Including the java -fullversion is encouraged for bugs in the JVM, hangs, network issues where the exact version can be critical to determine what fixes may be missing from an older version.
+* Provide the output of `java -version`  whenever possible - this version information is particularly critical for hangs, JVM bugs, and network issues.
 * Always file separate bugs for different issues.
-    * If two crashes looks related, but not similar enough to be sure they are the same, it's easier to later close a bug as a duplicate than it is to separate out one bug into two.
+    * If two crashes look related, but not similar enough to be sure they are the same, it's easier to later close a bug as a duplicate than it is to separate out one bug into two.
 
 Things to keep in mind when requesting an improvement:
 
@@ -173,7 +173,7 @@ style ClosedIncomplete fill:lightgreen
 
 ## Triaging an issue
 
-For the most OpenJDK groups Triage is performed on a regular basis (at least weekly) by triage teams. Each triage team consists of contributors who are area experts for that group of issues. If you haven't been selected to be part of a triage team for a specific area you shouldn't be triaging bugs in that area, unless you are the assignee.
+For the most OpenJDK groups Triage is performed on a regular basis (at least weekly) by triage teams. Each triage team consists of contributors who are area experts for that group of issues. If you haven't been selected to be part of a triage team for a specific area you shouldn't be triaging bugs in that area.
 
 When triaging an issue, first give it a general review
 
@@ -224,7 +224,7 @@ Some additional fields should be filled in as you get a better understanding of 
 
 ## Resolving an issue
 
-Once the work on an issue has been completed this should be indicated in JBS by moving the issue to a "closed" state.  There are two "closed" states: [Resolved]{.jbs-field} and [Closed]{.jbs-field} which can be used interchangeably except in the case of [Fixed]{.jbs-field}, or when flagged as  [Incomplete]{.jbs-field} (See Triaging).
+Once the work on an issue has been completed the issue should be in a "closed" state.  There are two "closed" states: [Resolved]{.jbs-field} and [Closed]{.jbs-field} which can be used interchangeably except in the case of [Fixed]{.jbs-field}, or when flagged as  [Incomplete]{.jbs-field} (See Triaging).
 
 <table class="dictionary" summary="JBS Label Dictionary">
   <tr style="text-align:left;"><th>Type</th><th>Covers</th></tr>
@@ -264,7 +264,7 @@ Once the work on an issue has been completed this should be indicated in JBS by 
 </tr>
 <tr>
     <td class="dictionary">[External]{.jbs-field}</td>
-    <td class="dictionary">Use where the issue is due to a problem in a Java library (not shipped with the JDK) or an IDE or other external tool</td>
+    <td class="dictionary">Use where the issue is due to a problem in a Java library (not shipped with the JDK), an IDE or other external tool etc. where known it is good to provide a link to the site where the issue should be reported.</td>
 </tr>
 <tr>
     <td class="dictionary">[Not an Issue]{.jbs-field}</td>


### PR DESCRIPTION
Added overview on triaging issues, the bug states and process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/guide.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/100.diff">https://git.openjdk.org/guide/pull/100.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/guide/pull/100#issuecomment-1476612167)