### PR TITLE
Removed forwardporting

### DIFF
--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -7,13 +7,17 @@
 * [Skara documentation on backports](https://wiki.openjdk.org/display/SKARA/Backports)
 :::
 
-Development of the latest version of the JDK often results in bug fixes that might be interesting to include in some of the JDK update releases still being maintained. Moving a fix from a more recent release train (e.g. JDK 17) to an older release train (e.g. JDK 11) is called *backporting*.
+Development of the latest version of the JDK often results in bug fixes that might be interesting to include in some of the JDK update releases still being maintained or in a feature release stabilization repository. Moving a fix from a more recent release train (e.g. JDK 17) to an older release train (e.g. JDK 11) is called *backporting*.
 
-The guideline for what to backport into a specific update release will vary over the lifetime of that release. Initially more fixes are expected to be backported as new features and large changes introduced in a mainline release stabilize. Over time the focus will shift from stabilization to keeping it stable - the release will go into maintenance mode. This means that bug fixes that require larger disruptive changes are more likely to be made in mainline and backported to more recent release trains only, and not to older release trains.
+The guideline for what to backport into a specific release will vary over the lifetime of that release. Initially more fixes are expected to be backported as new features and large changes introduced in a mainline release stabilize. Over time the focus will shift from stabilization to keeping it stable - the release will go into maintenance mode. This means that bug fixes that require larger disruptive changes are more likely to be made in mainline and backported to more recent release trains only, and not to older release trains.
 
 Over time it's likely that the code base will diverge between mainline and any given update release, and the cost of backporting will increase. The cost in this case is not only the effort needed to perform the actual backport, but also the cost inferred by bugs introduced by the backport. This should be taken into consideration when deciding if a change should be backported or not. For more details on how to reason around what to backport, [this email from JDK 8 Updates Project lead Andrew Haley](https://mail.openjdk.org/pipermail/jdk8u-dev/2020-June/012002.html) has some guidelines for JDK 8u. The reasoning in this mail is specific to JDK 8u, but will in general apply to any JDK release in maintenance mode.
 
 Any change that originally required a CSR will require a new CSR to be backported unless the backport was covered by the initial CSR. Changes to Java SE specifications cannot be made in an update release without a Java SE Maintenance Release. CSR-related issues affect interfaces and behavior and must be very carefully scrutinized.
+
+## Backporting to a feature release stabilization repository
+
+During rampdown of a feature release there are two repositories in play, the release stabilization repository for the outgoing release, and the mainline repository where the next release is being developed. Any change going into the release stabilization repository is likely to be desired in mainline as well. When making a change intended both for the stabilization release and the mainline repository, you should always create your pull request targeting the mainline repository first, and then, once the pull request is integrated, backport the resulting commit to the release stabilization repository.
 
 ## Working with backports in JBS
 

--- a/src/guide/the-jdk-release-process.md
+++ b/src/guide/the-jdk-release-process.md
@@ -50,25 +50,6 @@ Even though there's nothing explicitly written in the process about deferring P1
 
 Please note that the priority of a bug doesn't change just because you want to get your fix in late in the release, or if you want to be able to defer it. The priority is based on the severity of the bug and if it was deemed to be a P2 before, you better have a really good explanation to why that conveniently has changed by the end of the release. Being hard to fix is **not** a reason to lower the priority of a bug.
 
-## Forward ports
-
-During the rampdown of a release there are two repositories in play, the stabilization fork for the outgoing release, and the mainline repository where the next release is being developed. Any bugfix going into the stabilization fork is likely to be desired in mainline as well. As a developer you should push your fix to the stabilization fork **only**, even if you intend for it to go to both repositories. Your fix will be forward ported to mainline.
-
-_All_ fixes that are pushed to the stabilization fork are forward ported to mainline. If you have a fix that is only intended for the stabilization fork you will have to **manually** back it out from mainline once it has been forward ported. In order to remember to do this you should file a backout isue in JBS before pushing your change to the stabilization fork. E.g., To push JDK-xxx to the stabilization fork but not to mainline, you need to file an issue, JDK-yyy, in JBS to back out the fix after it has been merged into mainline. Make sure the two JBS issues (JDK-xxx and JDK-yyy) are related so that it's easy to find one from the other.
-
-To clarify, as soon as you know that there is a fix that needs to go into the stabilization fork but not mainline, you should do the following:
-
-* File a bug, JDK-yyy, to cover the backout work
-* [Link]{.jbs-field} JDK-yyy to JDK-xxx using a `relates to` link
-* Set JDK-yyy's [Fix Version/s]{.jbs-field} to the release currently being developed in mainline
-* Add a comment describing the situation
-* Set the [Priority]{.jbs-field} to be relatively high (e.g., P3)
-* Make yourself a watcher of JDK-xxx so that you get a notification when it's forward ported
-
-Then, you have to wait until the JDK-xxx fix is forward ported to mainline before actually fixing JDK-yyy. Making these settings in JDK-yyy will help ensure that it won't be missed.
-
-There are examples in JBS where JDK-yyy has been created as a sub-task of JDK-xxx. This is **not** recommended since JDK-yyy stands a higher risk of being missed when it's not of type *Bug* but rather a *sub-task* of an already closed issue. In general it's not recommended to have open sub-tasks of closed issues - an issue shouldn't be closed unless all it's sub-tasks are closed. Also see [Backing out a change](#backing-out-a-change) for reference.
-
 ::: {.box}
 [To the top](#){.boxheader}
 :::


### PR DESCRIPTION
@edvbld is out for the next few months so on his request I took over the change from #105. I have updated the patch based on the changes I proposed in my review there.

This patch removes the instructions related to forwardporting as this is no longer a concept in OpenJDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/guide.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/107.diff">https://git.openjdk.org/guide/pull/107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/guide/pull/107#issuecomment-1573616228)