### PR TITLE
Allow backport from PR

### DIFF
--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -56,7 +56,7 @@ If the update release is in rampdown, changes are pushed to the release reposito
 
 ## Using the Skara tooling to help with backports
 
-The Skara tooling includes support for backports. [The official Skara documentation](https://wiki.openjdk.org/display/SKARA/Backports) describes in detail how to work with the tooling to create backport PRs on GitHub or using the CLI tools. As described in the documentation, the [`/backport`](https://wiki.openjdk.org/display/SKARA/Commit+Commands#CommitCommands-/backport) command can be used on a commit (not a PR!) to create the backport PR. If a backport PR is manually created, set the PR title to `Backport <original commit hash>`. This ensures that the bots will recognize it as a backport as opposed to a main fix specifically targeting an older release. One can tell whether or not the bots recognized a PR as a backport by the [backport]{.label} label being added if it's recognized.
+The Skara tooling includes support for backports. [The official Skara documentation](https://wiki.openjdk.org/display/SKARA/Backports) describes in detail how to work with the tooling to create backport PRs on GitHub or using the CLI tools. As described in the documentation, the [`/backport`](https://wiki.openjdk.org/display/SKARA/Commit+Commands#CommitCommands-/backport) command can be used on a commit or a PR to create the backport PR. If a backport PR is manually created, set the PR title to `Backport <original commit hash>`. This ensures that the bots will recognize it as a backport as opposed to a main fix specifically targeting an older release. One can tell whether or not the bots recognized a PR as a backport by the [backport]{.label} label being added if it's recognized.
 
 ## How to fix an incorrect backport creation in JBS
 


### PR DESCRIPTION
Minor update since the Skara tooling has been updated to allow backports from PRs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - no project role)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.org/guide.git pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/114.diff">https://git.openjdk.org/guide/pull/114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/guide/pull/114#issuecomment-1688743475)