### PR TITLE
Fix link in RN-NewFeature to point to a publicly visible bug.

### DIFF
--- a/src/guide/release-notes.md
+++ b/src/guide/release-notes.md
@@ -87,7 +87,7 @@ Unless labeled otherwise it will be assumed that the release note documents a ch
 :   A new feature or enhancement in the release.
     The [Summary]{.jbs-field} must be the item/API or new functionality.
     The [Description]{.jbs-field} must contain the name of the new feature, its intended function, and how a user can utilize it.
-    Example: [JDK-8193026](https://bugs.openjdk.org/browse/JDK-8193026)
+    Example: [JDK-8315443](https://bugs.openjdk.org/browse/JDK-8315443)
 
 [[RN-IssueFixed]{.jbs-label}]{#RN-IssueFixed}
 :   A significant issue which has been fixed. This would normally be a regression or an issue which was unknowingly released in a new feature.


### PR DESCRIPTION
The old bug linked from this section (JDK-8193026) isn't publicly visible, which isn't very useful. Found by Tagir Valeev when he followed this procedure to write a release note.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/guide.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/116.diff">https://git.openjdk.org/guide/pull/116.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/guide/pull/116#issuecomment-1703060415)