### PR TITLE
More details for Skara backports

### DIFF
--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -58,7 +58,16 @@ If your request to backport a change is denied, but you for some reason already 
 
 ## Using the Skara tooling to help with backports
 
-The Skara tooling includes support for backports. [The official Skara documentation](https://wiki.openjdk.org/display/SKARA/Backports) describes in detail how to work with the tooling to create backport PRs on [GitHub](https://github.com) or using the CLI tools. As described in the documentation, the [`/backport`](https://wiki.openjdk.org/display/SKARA/Commit+Commands#CommitCommands-/backport) command can be used on a commit or a PR to create the backport PR. If a backport PR is manually created, set the PR title to `Backport <original commit hash>`. This ensures that the bots will recognize it as a backport as opposed to a main fix specifically targeting an older release. One can tell whether or not the bots recognized a PR as a backport by the [backport]{.label} label being added if it's recognized.
+The Skara tooling includes support for backports. [The official Skara documentation](https://wiki.openjdk.org/display/SKARA/Backports) describes in detail how to work with the tooling to create backport PRs on [GitHub](https://github.com) or using the CLI tools. As described in the documentation, the [`/backport`](https://wiki.openjdk.org/display/SKARA/Commit+Commands#CommitCommands-/backport) command can be used on a commit or a PR to create the backport PR:
+
+    /backport jdk21u
+    /backport jdk jdk23
+
+In the first example we backport the change to JDK 21. To backport to other update releases, replace `jdk21u` with the corresponding name for the target update repository.
+
+The second example above will backport the change to a stabilization branch, in this case JDK 23. As before `jdk` is the name of the target repository, and `jdk23` is the name of the stabilization branch.
+
+Using the `/backport` command is the recommended way to perform backports as the tooling will automatically handle all the necessary steps in the background. If a backport PR is manually created, set the PR title to `Backport <original commit hash>`. This ensures that the bots will recognize it as a backport as opposed to a main fix specifically targeting an older release. One can tell whether or not the bots recognized a PR as a backport by the [backport]{.label} label being added if it's recognized.
 
 ## How to fix an incorrect backport creation in JBS
 

--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -64,7 +64,7 @@ The Skara tooling includes support for backports. [The official Skara documentat
     /backport jdk jdk23
     /backport :jdk23
 
-In the first example we backport the change to JDK 21. To backport to other update releases, replace `jdk21u` with the corresponding name for the target update repository.
+In the first example we backport the change to the JDK 21 update release. To backport to other update releases, replace `jdk21u` with the corresponding name for the target update repository.
 
 The second and third example above will backport the change to a stabilization branch, in this case JDK 23. As before `jdk` is the name of the target repository, and `jdk23` is the name of the stabilization branch.
 

--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -62,10 +62,11 @@ The Skara tooling includes support for backports. [The official Skara documentat
 
     /backport jdk21u
     /backport jdk jdk23
+    /backport :jdk23
 
 In the first example we backport the change to JDK 21. To backport to other update releases, replace `jdk21u` with the corresponding name for the target update repository.
 
-The second example above will backport the change to a stabilization branch, in this case JDK 23. As before `jdk` is the name of the target repository, and `jdk23` is the name of the stabilization branch.
+The second and third example above will backport the change to a stabilization branch, in this case JDK 23. As before `jdk` is the name of the target repository, and `jdk23` is the name of the stabilization branch.
 
 Using the `/backport` command is the recommended way to perform backports as the tooling will automatically handle all the necessary steps in the background. If a backport PR is manually created, set the PR title to `Backport <original commit hash>`. This ensures that the bots will recognize it as a backport as opposed to a main fix specifically targeting an older release. One can tell whether or not the bots recognized a PR as a backport by the [backport]{.label} label being added if it's recognized.
 

--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -60,7 +60,7 @@ If your request to backport a change is denied, but you for some reason already 
 
 The Skara tooling includes support for backports. [The official Skara documentation](https://wiki.openjdk.org/display/SKARA/Backports) describes in detail how to work with the tooling to create backport PRs on [GitHub](https://github.com) or using the CLI tools. As described in the documentation, the [`/backport`](https://wiki.openjdk.org/display/SKARA/Commit+Commands#CommitCommands-/backport) command can be used on a commit or a PR to create the backport PR:
 
-    /backport jdk21u
+    /backport jdk21u-dev
     /backport jdk jdk23
     /backport :jdk23
 

--- a/src/guide/cloning-the-jdk.md
+++ b/src/guide/cloning-the-jdk.md
@@ -53,7 +53,7 @@ Here we create a new branch called `JDK-8272373` based on the `master` branch an
 
 If you intend to work on a backport to a feature release stabilization branch, your new local branch should of course be based on the stabilization branch instead of `master`.
 
-    $ git switch -c JDK-8272373 origin/jdk23u
+    $ git switch -c JDK-8272373 jdk23
 
 `git switch` was introduced in Git version 2.23. For earlier versions of Git `git checkout` can be used instead. However it is always recommended to use the latest versions of all your tools when possible.
 


### PR DESCRIPTION
Added some more details around using the /backport command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - no project role) ⚠️ Review applies to [96e9c728](https://git.openjdk.org/guide/pull/124/files/96e9c7287ea95df778124bdadacc511a26a644de)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [96e9c728](https://git.openjdk.org/guide/pull/124/files/96e9c7287ea95df778124bdadacc511a26a644de)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/guide.git pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/124.diff">https://git.openjdk.org/guide/pull/124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/guide/pull/124#issuecomment-2150818248)