### PR TITLE
Misc minor updates

### DIFF
--- a/src/guide/code-owners.md
+++ b/src/guide/code-owners.md
@@ -167,7 +167,8 @@ This list is intended to make it easier to identify which email list to include 
 * [jdk.crypto.mscapi](https://github.com/openjdk/jdk/tree/master/src/jdk.crypto.mscapi) - Security
 * [jdk.dynalink](https://github.com/openjdk/jdk/tree/master/src/jdk.dynalink) - Tools
 * [jdk.editpad](https://github.com/openjdk/jdk/tree/master/src/jdk.editpad) - JShell
-* [[jdk.graal.compiler](https://github.com/openjdk/jdk/tree/master/jdk.graal.compiler), [jdk.graal.compiler.management](https://github.com/openjdk/jdk/tree/master/jdk.graal.compiler.management)]/jdk.graal.* - Compiler
+* [jdk.graal.compiler](https://github.com/openjdk/jdk/tree/master/src/jdk.graal.compiler) - Compiler
+* [jdk.graal.compiler.management](https://github.com/openjdk/jdk/tree/master/src/jdk.graal.compiler.management) - Compiler
 * [jdk.hotspot.agent](https://github.com/openjdk/jdk/tree/master/src/jdk.hotspot.agent) - Serviceability
 * [jdk.httpserver](https://github.com/openjdk/jdk/tree/master/src/jdk.httpserver) - Net
 * [jdk.incubator.vector](https://github.com/openjdk/jdk/tree/master/src/jdk.incubator.vector) - Compiler
@@ -227,7 +228,7 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.internal.vm.compiler` – Compiler (Removed in [22](https://bugs.openjdk.org/browse/JDK-8318027))
 * `jdk.internal.vm.compiler.management` – Compiler (Removed in [22](https://bugs.openjdk.org/browse/JDK-8318027))
 * `jdk.pack` – Tools (Removed in [14](https://bugs.openjdk.org/browse/JDK-8234596))
-* `jdk.random` – Core Libs (Unknown when it was Removed)
+* `jdk.random` – Core Libs (Removed in [23](https://bugs.openjdk.org/browse/JDK-8330005))
 * `jdk.rmic` – Core Libs (Removed in [15](https://bugs.openjdk.org/browse/JDK-8225319))
 * `jdk.scripting.nashorn` – Tools (Removed in [15](https://bugs.openjdk.org/browse/JDK-8236933))
 * `jdk.scripting.nashorn.shell` – Tools (Removed in [15](https://bugs.openjdk.org/browse/JDK-8236933))

--- a/src/guide/code-owners.md
+++ b/src/guide/code-owners.md
@@ -67,7 +67,7 @@ This list is intended to make it easier to identify which email list to include 
     * [com/sun/crypto](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/com/sun/crypto) - Security
     * [com/sun/security](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/com/sun/security) - Security
     * [crypto](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/javax/crypto) - Security
-    * [[linux](https://github.com/openjdk/jdk/tree/master/java.base/linux/classes/jdk/internal), [macosx](https://github.com/openjdk/jdk/tree/master/java.base/macosx/classes/jdk/internal), [share](https://github.com/openjdk/jdk/tree/master/java.base/share/classes/jdk/internal), [unix](https://github.com/openjdk/jdk/tree/master/java.base/unix/classes/jdk/internal), [windows](https://github.com/openjdk/jdk/tree/master/java.base/windows/classes/jdk/internal)]/internal
+    * [[aix](https://github.com/openjdk/jdk/tree/master/java.base/aix/classes/jdk/internal), [linux](https://github.com/openjdk/jdk/tree/master/java.base/linux/classes/jdk/internal), [macosx](https://github.com/openjdk/jdk/tree/master/java.base/macosx/classes/jdk/internal), [share](https://github.com/openjdk/jdk/tree/master/java.base/share/classes/jdk/internal), [unix](https://github.com/openjdk/jdk/tree/master/java.base/unix/classes/jdk/internal), [windows](https://github.com/openjdk/jdk/tree/master/java.base/windows/classes/jdk/internal)]/internal
       * [access](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/access) - Core Libs, Security
       * [event](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/event) - JFR
       * [foreign](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/foreign) - Core Libs
@@ -77,7 +77,7 @@ This list is intended to make it easier to identify which email list to include 
       * [jimage](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/jimage) - Core Libs
       * [jmod](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/jmod) - Core Libs
       * [jrtfs](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/jrtfs) - Core Libs
-      * [[macosx](https://github.com/openjdk/jdk/tree/master/java.base/macosx/classes/jdk/internal/loader), [share](https://github.com/openjdk/jdk/tree/master/java.base/share/classes/jdk/internal/loader), [unix](https://github.com/openjdk/jdk/tree/master/java.base/unix/classes/jdk/internal/loader), [windows](https://github.com/openjdk/jdk/tree/master/java.base/windows/classes/jdk/internal/loader)]/loader - Core Libs
+      * [[aix](https://github.com/openjdk/jdk/tree/master/java.base/aix/classes/jdk/internal/loader), [macosx](https://github.com/openjdk/jdk/tree/master/java.base/macosx/classes/jdk/internal/loader), [share](https://github.com/openjdk/jdk/tree/master/java.base/share/classes/jdk/internal/loader), [unix](https://github.com/openjdk/jdk/tree/master/java.base/unix/classes/jdk/internal/loader), [windows](https://github.com/openjdk/jdk/tree/master/java.base/windows/classes/jdk/internal/loader)]/loader - Core Libs
       * [logger](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/logger) - Core Libs
       * [math](https://github.com/openjdk/jdk/tree/master/src/java.base/share/classes/jdk/internal/math) - Core Libs
       * [[share](https://github.com/openjdk/jdk/tree/master/java.base/share/classes/jdk/internal/misc), [unix](https://github.com/openjdk/jdk/tree/master/java.base/unix/classes/jdk/internal/misc), [windows](https://github.com/openjdk/jdk/tree/master/java.base/windows/classes/jdk/internal/misc)]/misc - Core Libs, HotSpot
@@ -197,7 +197,6 @@ This list is intended to make it easier to identify which email list to include 
 * [jdk.naming.rmi](https://github.com/openjdk/jdk/tree/master/src/jdk.naming.rmi) - Core Libs
 * [jdk.net](https://github.com/openjdk/jdk/tree/master/src/jdk.net) - Net
 * [jdk.nio.mapmode](https://github.com/openjdk/jdk/tree/master/src/jdk.nio.mapmode) - NIO
-* [jdk.random](https://github.com/openjdk/jdk/tree/master/src/jdk.random) - Core Libs
 * [jdk.sctp](https://github.com/openjdk/jdk/tree/master/src/jdk.sctp) - Net
 * [jdk.security.auth](https://github.com/openjdk/jdk/tree/master/src/jdk.security.auth) - Security
 * [jdk.security.jgss](https://github.com/openjdk/jdk/tree/master/src/jdk.security.jgss) - Security
@@ -228,6 +227,7 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.internal.vm.compiler` – Compiler (Removed in [22](https://bugs.openjdk.org/browse/JDK-8318027))
 * `jdk.internal.vm.compiler.management` – Compiler (Removed in [22](https://bugs.openjdk.org/browse/JDK-8318027))
 * `jdk.pack` – Tools (Removed in [14](https://bugs.openjdk.org/browse/JDK-8234596))
+* `jdk.random` – Core Libs (Unknown when it was Removed)
 * `jdk.rmic` – Core Libs (Removed in [15](https://bugs.openjdk.org/browse/JDK-8225319))
 * `jdk.scripting.nashorn` – Tools (Removed in [15](https://bugs.openjdk.org/browse/JDK-8236933))
 * `jdk.scripting.nashorn.shell` – Tools (Removed in [15](https://bugs.openjdk.org/browse/JDK-8236933))

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -83,12 +83,12 @@ The [Affects Version/s]{.jbs-field} field is used to indicate which releases an 
 Another aspect of an issue is when the feature it's a part of was added or removed from the JDK, which in either case limits the range of releases the issue impacts. Knowing that a feature was removed before the oldest currently maintained release means it can be resolved as [Won't Fix]{.jbs-value}.
 
 #### Setting the Affects Version/s field
-Set the [Affects Version/s]{.jbs-field} field to the lowest release value that the bug is known to be reproducible on.
+Set the [Affects Version/s]{.jbs-field} field to the lowest release where the bug has been seen.
 
-* The [Affects Version/s]{.jbs-field} isn't meant to be an exhaustive list of releases the issue is relevant to - it should initially be set to the release the issue was reproduced or identified on, and by implication it will be relevant to all releases past that point (see [Usage of (Rel)[-na]{.jbs-label} Label](#usage-of-rel-na-label)). If it's later found to be applicable to an earlier release family then adding that earlier release is encouraged if the issue needs to be fixed in that release.
+* The [Affects Version/s]{.jbs-field} isn't meant to be an exhaustive list of releases the issue is relevant to - it should initially be set to the release the issue was reproduced or identified on, and by implication it will be relevant to all releases past that point (see [Usage of the (Rel)[-na]{.jbs-label} Label](#usage-of-rel-na-label)). If it's later found to be applicable to an earlier release family then adding that earlier release is encouraged if the issue needs to be fixed in that release.
 * Don't add additional release values to [Affects Version/s]{.jbs-field} for the same release family. For example, if there is the value [11.0.2]{.jbs-value}, don't add [11.0.5]{.jbs-value}, [11.0.7]{.jbs-value} etc. Adding an additional value for a separate release family where it's still reproducible, e.g. JDK [21]{.jbs-value}, is encouraged if there isn't currently a feature release value set, or, it has been a few releases since it was last reproduced/reviewed. For example, if the [Affects Version/s]{.jbs-field} is JDK [8]{.jbs-value}, but it is still relevant to the latest mainline release.
 
-#### Usage of (Rel)-na Label
+#### Usage of the (Rel)-na Label
 
 Labels of the form (Rel)[-na]{.jbs-label} (eg. [17-na]{.jbs-label}) should be used when a bug is not applicable to a more recent release family. For example:
 
@@ -102,10 +102,11 @@ Don't:
 
   [Affects Version/s]{.jbs-field}: [11.0.20]{.jbs-value}, [17]{.jbs-value}
 
-  the label [8-na]{.jbs-label} would not be needed - as it doesn't have a JDK 8 release, or earlier, value in the [Affects Version/s]{.jbs-field}, it is not relevant to JDK 8.
+  the label [8-na]{.jbs-label} would not be needed - as it doesn't have a JDK 8 release, or earlier, value in the [Affects Version/s]{.jbs-field}, it is not relevant to JDK 8. Also see [Usage of the (Rel)[-wnf]{.jbs-label} Label](#usage-of-rel-wnf-label)
 - add multiple [-na]{.jbs-label} labels: you only need one, for example don't add both [9-na]{.jbs-label} and [11-na]{.jbs-label} — [9-na]{.jbs-label} implies all following releases therefore [11-na]{.jbs-label}, or [17-na]{.jbs-label} etc. are not needed.
+- It's not recommended to specify update releases like 17u4 or 21u in the label. Labels like [17-na]{.jbs-label} and [21-na]{.jbs-label} are in general enough.
 
-#### Usage of (Rel)-wnf Label
+#### Usage of the (Rel)-wnf Label
 
 Labels of the form (Rel)[-wnf]{.jbs-label} (e.g. [11-wnf]{.jbs-label}) should be used to indicate that a bug is not going to be fixed in a release that it's applicable to, or any earlier releases. For example, [11-wnf]{.jbs-label} states it won't be fixed in JDK 11 and implicitly indicates it won't be fixed in JDK 8 either.
 
@@ -418,15 +419,9 @@ This table contains some frequently used JBS labels and their meaning. Please he
   <tr>
     <td class="dictionary">[*(Rel)*[-na]{.jbs-label}]{#rel-na}</td>
     <td class="dictionary">
-      Labels of the form [11-na]{.jbs-label} or [21-na]{.jbs-label} should be used when a bug is not applicable to a **more recent** release family.
+      Labels of the form [11-na]{.jbs-label} or [21-na]{.jbs-label} should be used when a bug is not applicable to a **more recent** release family. See [Usage of the (Rel)-na Label].
 
-      The [Affects Version/s]{.jbs-field} field is used to indicate the releases where an issue has been seen - it's implied that the issue is also applicable to newer releases. Where this isn't the case - for instance a bug in code that was removed in *(Rel)* - then use *(Rel)*[-na]{.jbs-label} to indicate this. Note that there should only be **one** *(Rel)*[-na]{.jbs-label} label on any JBS issue. The label indicates the first known release where the issue is not present. If it's found that the issue is not present in an earlier release, change the label to indicate this.
-
-      It's not recommended to specify update releases like 17u4 or 21u in the label. Please stick to labels like [17-na]{.jbs-label} and [21-na]{.jbs-label}.
-
-      Don't use this label to indicate that a bug isn't relevant to an earlier release where it's present in a later release. If a bug is not present in an earlier release you can use [Introduced in Version]{.jbs-field} to indicate where the bug was introduced. If a bug is present in an earlier release, but shouldn't be fixed there, use [*(Rel)*[-wnf]{.jbs-label}]{#rel-wnf}.
-
-      Also see [Usage of (Rel)-na Label].
+      (Rel) can also refer to more general release atrifacts like [oraclejdk-na]{.jbs-label}, [openjdk-na]{.jbs-label}, and [sap-aix-na]{.jbs-label} to indicate that the issue doesn't affect code included in that specific atrifact.
     </td>
   </tr>
   <tr>
@@ -434,7 +429,7 @@ This table contains some frequently used JBS labels and their meaning. Please he
     <td class="dictionary">
       Labels of the form [11-wnf]{.jbs-label} or [21-wnf]{.jbs-label} should be used to indicate that a bug is not going to be fixed in a release where it's present. Note that there should only be **one** *(Rel)*[-wnf]{.jbs-label} label on any JBS issue. It is implied that earlier versions will not be fixed either.
 
-      Also see [Usage of (Rel)-wnf Label].
+      Also see [Usage of the (Rel)-wnf Label].
     </td>
   </tr>
   <!-- Team -->
@@ -473,7 +468,7 @@ This table contains some frequently used JBS labels and their meaning. Please he
     <td class="dictionary">
       Used to identify issues in the JVM JIT compiler C2.
 
-      [c2-]{.jbs-label}`.*` labels are used to identify different c2 features. E.g., [c2-intrinsic]{.jbs-label}, [c2-loopopts]{.jbs-label}
+      [c2-]{.jbs-label}`.*` labels are used to identify different C2 features. E.g., [c2-intrinsic]{.jbs-label}, [c2-loopopts]{.jbs-label}
     </td>
   </tr>
   <tr>

--- a/src/guide/release-notes.md
+++ b/src/guide/release-notes.md
@@ -24,15 +24,16 @@ The release note itself is written in a [JBS](#jbs---jdk-bug-system) sub-task of
 #. Create a sub-task (More &rightarrow; Create Sub-Task) for the issue that requires a release note - the main issue, that is, the JBS issue that is used to integrate the original change, **not** for backports or the CSR (if there is one).
 
 #. For the newly created sub-task, follow these steps:
+   * While the [Priority]{.jbs-field} of the sub-task is set by default to be the same as the priority of the issue itself, it can be changed to adjust in what order the release note is listed compared to other release notes in the same build or release note section.
+   * Set the [Assignee]{.jbs-field} to the same person who owns the main issue.
    * The [Summary]{.jbs-field} should be a one sentence synopsis that is informative (and concise) enough to attract the attention of users, developers, and maintainers who might be impacted by the change. It should succinctly describe what has actually changed, not be the original bug title, nor describe the problem that was being solved. It should read well as a sub-section heading in a document.
    * Prefix the [Summary]{.jbs-field} with "Release Note:".
+   * Enter the text of the release note in the [Description]{.jbs-field} field using markdown formatting, following the [CommonMark specification](https://spec.commonmark.org/current/). While the markdown won't be rendered in JBS, you can use [dingus](https://spec.commonmark.org/dingus/) to see what the release note will look like. Note that [Github style ascii table formatting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables) is supported but will not display correctly in the dingus page. For more information see [General Conventions for Release Notes] below.
+   * Set [Component/s]{.jbs-field} and [Subcomponent]{.jbs-field} to the same values as the original bug.
+   * Set [Affects Version/s]{.jbs-field} to the release versions for which the release note should be published.
    * Add the [release-note]{.jbs-label} label. This is required for the release note to be included in the release notes.
    * Add the proper [RN-]{.jbs-label}label if applicable to indicate what section of the release notes it should be included in (see [RN-labels] below).
-   * Set the [Assignee]{.jbs-field} to the same person who owns the main issue.
-   * Set [Affects Version/s]{.jbs-field} to the release versions for which the release note should be published.
    * Set the [Fix Version/s]{.jbs-field} to the same value that the main issue - in almost all cases this will be the version of mainline.
-   * Enter the text of the release note in the [Description]{.jbs-field} field using markdown formatting, following the [CommonMark specification](https://spec.commonmark.org/current/). While the markdown won't be rendered in JBS, you can use [dingus](https://spec.commonmark.org/dingus/) to see what the release note will look like. Note that [Github style ascii table formatting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables) is supported but will not display correctly in the dingus page. For more information see [General Conventions for Release Notes] below.
-   * While the [Priority]{.jbs-field} of the sub-task is set by default to be the same as the priority of the issue itself, it can be changed to adjust in what order the release note is listed compared to other release notes in the same build or release note section.
 
 #. Have the release note ready to be reviewed at the same time as the code is reviewed. If it's later determined that a release note is necessary, then go back to the same engineers who reviewed the fix to review the release note.  Special care should be taken when writing a release note that will cover changes related to a vulnerability fix in order to avoid describing technical details of how it could have been exploited.
 


### PR DESCRIPTION
* Updated code owners
* Removed text duplication around the -na labels
* Fixed typos
* Changed the order of fields in the Release Note creation to match the order in JBS and added a note about Component/Subcomponent

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [2a8822bb](https://git.openjdk.org/guide/pull/132/files/2a8822bbfeded64e8942cf52f725f89ed2c0127b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/guide.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/132.diff">https://git.openjdk.org/guide/pull/132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/guide/pull/132#issuecomment-2253021318)