### PR TITLE
Describe in JBS before PR

### DIFF
--- a/src/guide/working-with-pull-requests.md
+++ b/src/guide/working-with-pull-requests.md
@@ -10,6 +10,10 @@ Once you have made a change that you want to integrate into an OpenJDK code base
 
 This section also assumes that you have already read [I have a patch, what do I do?] and followed **all** the steps there.
 
+::: {.note}
+Please note that the description of a change should always be in the JBS issue. The [GitHub](https://github.com) PR can be a good place to discuss technical implementation details regarding your change, but it's not the right place to describe the problem. Make sure you have a proper problem description in your JBS issue before publishing a PR.
+:::
+
 ## Think once more
 
 All code reviews in OpenJDK are done in public. Once you open your PR for public review the internet can see it and comment on it. Make sure your code is ready for it. Look through your comments, make sure that temporary code is gone, and make sure you have sanitized your method and variable names. Also, make sure you understand your code. Why is it working? What are the potential pitfalls? What are the edge-cases? If you haven't already answered all these questions in the mail conversation that preceded this PR, it's likely that you will need to answer them during the review.


### PR DESCRIPTION
Added a note to remind to have a description in JBS before creating a PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/141/head:pull/141` \
`$ git checkout pull/141`

Update a local copy of the PR: \
`$ git checkout pull/141` \
`$ git pull https://git.openjdk.org/guide.git pull/141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 141`

View PR using the GUI difftool: \
`$ git pr show -t 141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/141.diff">https://git.openjdk.org/guide/pull/141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/141#issuecomment-2619728669)
</details>
