### PR TITLE
Put toc on the side

### DIFF
--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -258,26 +258,27 @@ Some additional fields should be filled out or updated as you get a better under
 * The [Description]{.jbs-field} usually explains what went wrong and how the failure was found, then there's some investigation and eventually the root cause is found. At this point the [Summary]{.jbs-field} should be updated to correctly describe the bug. The [Description]{.jbs-field} however should remain a description of how the failure was found.
 * The [Affects Version/s]{.jbs-field} should be updated if you in your investigation finds that the issue is older than what is indicated by the current [Affects Version/s]{.jbs-field}.
 
-### Linking Issues
+::: {.note}
+**Note:** If during your investigation of the bug you determine that the issue is in the wrong component, make sure to move it back to the [New]{.jbs-value} state before moving it to the new component, so that it will be picked up by the component's triage team. Make sure there is a comment outlining the reason for the move, as explained above.
+:::
+
+## Linking Issues
 
 An important aspect of any issue is making clear how it is connected/related to other issues. This can occur at any stage of the issue's lifecycle. For example, as information becomes available that might suggest a cause, or similar issue (relates to).
 
 There are the following link types:
 
-[duplicate of]{.jbs-value} - Normally set automatically - see [Closing issues as duplicates] for more information
-
-[backported by]{.jbs-value} - Normally set automatically when creating a backport with the “More -> Create Backport” option, or by the Skara tooling
-
-[CSR for]{.jbs-value} - When creating a CSR with the “More -> Create CSR” option, a link is automatically created between the main issue and the new CSR
-
-[blocks]{.jbs-value} - For when other issues are dependent on the current issue being resolved/fixed before they can be. For example, when a fix is broken down into a number of parts the [blocks]{.jbs-value} link should be used to ensure they are all fixed before the main issue is considered resolved - see [implementing large changes](#implementing-large-changes]
-
-[relates to]{.jbs-value} - To avoid lots of [relates to]{.jbs-value} links, the links should have some significance in relation to the cause and/or fix, for the current issue. In addition, relates links should not duplicate an existing [duplicated by]{.jbs-value}, [backported by]{.jbs-value}, [csr for]{.jbs-value} or [blocked by]{.jbs-value} link.  In particular, it may be necessary to manually remove a [relates to]{.jbs-value} link if it is later added as a [duplicated by]{.jbs-value} or [caused by]{.jbs-value} link
-
-[causes]{.jbs-value}/[caused by]{.jbs-value} - the [causes]{.jbs-value} link implies a stronger relationship than [relates to]{.jbs-value}. If an issue 'B' can be traced back to the fix for issue 'A' then ‘A causes B’ (or ‘B is caused by A’)
+| Type | Usage |
+|:-|:----------|
+| [duplicate of]{.jbs-value} | Normally set automatically when an issue is closed as a duplicate - see [Closing issues as duplicates] for more information. |
+| [backported by]{.jbs-value} | Normally set automatically when creating a backport with the “More -> Create Backport” option, or by the Skara tooling. |
+| [CSR for]{.jbs-value} | When creating a CSR with the “More -> Create CSR” option, a link is automatically created between the main issue and the new CSR. |
+| [blocks]{.jbs-value} | For when other issues are dependent on the current issue being resolved/fixed before they can be. For example, when a fix is broken down into a number of parts the [blocks]{.jbs-value} link should be used to ensure they are all fixed before the main issue is considered resolved - see [Implementing a large change]. |
+| [relates to]{.jbs-value} | Used to indicate a relationship between two issues. To avoid lots of [relates to]{.jbs-value} links, the links should have some significance in relation to the cause and/or fix, for the current issue. |
+| [causes]{.jbs-value}/[caused by]{.jbs-value} | The [causes]{.jbs-value} link implies a stronger relationship than [relates to]{.jbs-value}. If an issue 'B' can be traced back to the fix for issue 'A' then ‘A causes B’ (or ‘B is caused by A’). |
 
 ::: {.note}
-**Note:** If during your investigation of the bug you determine that the issue is in the wrong component, make sure to move it back to the [New]{.jbs-value} state before moving it to the new component, so that it will be picked up by the component's triage team. Make sure there is a comment outlining the reason for the move, as explained above.
+**Note:** There should never be more than one type of link between two issues. It may be necessary to manually remove a link, e.g. [relates to]{.jbs-value}, if later a [duplicated by]{.jbs-value} or [caused by]{.jbs-value} link is added.
 :::
 
 ## Resolving or Closing an issue
@@ -310,11 +311,11 @@ The [Fix Version/s]{.jbs-field} field should indicate when an issue was fixed. T
 | [Future Project]{.jbs-value} | This status is not recommended for use. |
 | [Rejected]{.jbs-value} | This status should not be used. |
 
-:::{.note}
+::: {.note}
 When an issue is closed as [Won't Fix]{.jbs-value}, do not remove the [Fix Version/s]{.jbs-field}. It's valuable information to know what version it was decided not to fix an issue in. The same goes for resolutions such as [Duplicate]{.jbs-value}, [Cannot Reproduce]{.jbs-value} and [Not an Issue]{.jbs-value}.
 :::
 
-:::{.note}
+::: {.note}
 The fix version [na]{.jbs-value} should only be used on backport issues that is created by mistake. See [How to fix an incorrect backport creation in JBS].
 :::
 

--- a/src/guide/working-with-pull-requests.md
+++ b/src/guide/working-with-pull-requests.md
@@ -84,13 +84,13 @@ If you have an actual reason to create a PR before the change is all done, make 
 
 #. **Allow enough time for review**
 
-   In general all PRs should be open for at least 24 hours to allow for reviewers in all time zones to get a chance to see it. It may actually happen that even 24 hours isn't enough. Take into account weekends, holidays, and vacation times throughout the world and you'll realize that a change that requires more than just a trivial review may have to be open for a while. In some areas [trivial] changes are allowed to be integrated without the 24 hour delay. Ask your reviewers if you think this applies to your change.
+   In general all PRs should be open for at least 24 hours to allow for reviewers in all time zones to get a chance to see it. It may actually happen that even 24 hours isn't enough. Take into account weekends, holidays, and vacation times throughout the world and you'll realize that a change that requires more than just a trivial review may have to be open for a while. In some areas [trivial changes] are allowed to be integrated without the 24 hour delay. Ask your reviewers if you think this applies to your change.
 
 #. **Get the required reviews**
 
    At least one [Reviewer](https://openjdk.org/bylaws#reviewer) knowledgeable in each area being changed must approve every change. A change may therefore require multiple [Reviewers](https://openjdk.org/bylaws#reviewer) because it affects multiple areas. Some areas (e.g. Client and HotSpot) require two reviewers in most cases, so be sure to read the relevant [OpenJDK Group](https://openjdk.org/bylaws#group) pages for advice or ask your [Sponsor](https://openjdk.org/bylaws#sponsor).
 
-   Be open to comments and polite in replies. Remember that the reviewer wants to improve the world just as much as you do, only in a slightly different way. If you don't understand some comment, ask the reviewer to clarify. Accept authority when applicable. If you're making changes in an area where you're not the area expert, acknowledge that your reviewers may be. Take their advice seriously, even if it is to not make the change. There are many reasons [why a change may get rejected](#why-is-my-change-rejected). And you did read the section [Things to consider before changing OpenJDK code], right?
+   Be open to comments and polite in replies. Remember that the reviewer wants to improve the world just as much as you do, only in a slightly different way. If you don't understand some comment, ask the reviewer to clarify. Accept authority when applicable. If you're making changes in an area where you're not the area expert, acknowledge that your reviewers may be. Take their advice seriously, even if it is to not make the change. There are many reasons [why a change may get rejected](#why-is-my-change-rejected). And you did read the section [Things to consider before proposing changes to OpenJDK code], right?
 
 #. **Updating the PR**
 

--- a/src/guidestyle.css
+++ b/src/guidestyle.css
@@ -116,3 +116,21 @@ strong > code {
     white-space: nowrap;
     color: #060;
 }
+
+div#TOC {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    width: 27em;
+    max-height: 100vh;
+    overflow-y: auto;
+}
+
+@media (max-width: 81em) {
+  div#TOC {
+    position: static;
+    max-height: none;
+    overflow-y: visible;
+  }
+}


### PR DESCRIPTION
Fix the table of contents to the right side for easier navigation.
Also some minor bug fixes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/guide.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/142.diff">https://git.openjdk.org/guide/pull/142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/142#issuecomment-2672548233)
</details>
