### PR TITLE
Add material about updating the CSR when a backout occurs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ all: $(GUIDE_RESULT) build/dist/guidestyle.css copyimages
 
 clean:
 	rm -rf build
-	rm mermaid-filter.err
+	rm -f mermaid-filter.err
 
 validate: build/dist/index.html
 	tidy -q -ascii -asxhtml -n --doctype omit --tidy-mark n build/dist/index.html > /dev/null

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -335,8 +335,7 @@ ProblemList entries and `@ignore` keywords will continue to point to the origina
 
 ### How to work with git when a change is backed out
 
-To backout a change with git, use `git revert`. This will apply (commit) the anti-delta of the change.
-Then proceed as usual with creating a PR and getting it reviewed.
+To backout a change with git, use `git revert`. This will apply (commit) the anti-delta of the change. Then proceed as usual with creating a PR and getting it reviewed.
 
 ~~~diff
 $ git show aa371b4f02c2f809eb9cd3e52aa12b639bed1ef5

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -326,12 +326,17 @@ There are two parts to this task, how to do the bookkeeping in JBS, and how to d
    * Alternative 3 - no redo issue was created.
      * Create a backout-issue **(B)** with the same summary as **(O)**, prefix with `[BACKOUT]`.
      * Add a _relates to_ link between **(B)** and **(O)**.
+#. If **(O)** had a CSR request, update the CSR issue as follows:
+   * Add a csr-for link from the CSR to **(R)**.
+   * Add a note to the CSR that explains the reason for the redo and the impact on the CSR.
+   * Move the CSR back into the Finalized state for re-review. (It's necessary to first move the CSR back to the Draft state before moving it to the Finalized state.)
 
 ProblemList entries and `@ignore` keywords will continue to point to the original bug (unless updated at back out). This is accepted since there is a clone link to follow.
 
 ### How to work with git when a change is backed out
 
 To backout a change with git, use `git revert`. This will apply (commit) the anti-delta of the change.
+Then proceed as usual with creating a PR and getting it reviewed.
 
 ~~~diff
 $ git show aa371b4f02c2f809eb9cd3e52aa12b639bed1ef5


### PR DESCRIPTION
Also, add a small fix to the Makefile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**) ⚠️ Review applies to [a9f26da3](https://git.openjdk.org/guide/pull/148/files/a9f26da3816fd18aeb929c25de8f9c00f76e190f)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/guide.git pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/148.diff">https://git.openjdk.org/guide/pull/148.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/148#issuecomment-2791043071)
</details>
