### PR TITLE
Update affects_versions.svg

### DIFF
--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -125,26 +125,26 @@
         </marker>
     </defs>
 
-    <text x="25" y="52">8</text>
+    <text x="25" y="54">8</text>
     <path d="M 45, 56 L 495, 56"
           marker-end="url(#arrow)"/>
 
-    <text x="25" y="82">8,
+    <text x="25" y="84">8,
         <tspan fill="red">8u40, 9, 12</tspan></text>
     <path d="M 45, 86 L 495, 86"
           marker-end="url(#arrow)"/>
 
-    <text x="25" y="112">11, 21</text>
+    <text x="25" y="114">11, 21</text>
     <path d="M 135, 116 L 495, 116"
           marker-end="url(#arrow)"/>
 
-    <text x="25" y="142">8</text>
-    <text x="165" y="142" text-anchor="middle">12-na</text>
+    <text x="25" y="144">8</text>
+    <text x="165" y="144" text-anchor="middle">12-na</text>
     <path d="M  45, 146 L 135, 146"
           marker-end="url(#circle)"/>
 
-    <text x="25" y="172">8</text>
-    <text x="135" y="172" style="text-anchor: middle">11-wnf</text>
+    <text x="25" y="174">8</text>
+    <text x="135" y="174" style="text-anchor: middle">11-wnf</text>
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"
           marker-end="url(#circle)"/>

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -153,12 +153,8 @@
                  M 138, 173 L 132, 179"
               style="stroke: red"/>
     </g>
-    <use
-          x="-90"
-          y="0"
-          xlink:href="#red-cross"
-          stroke-width="2"
-    />
+    <use x="-90" y="0" stroke-width="2"
+         xlink:href="#red-cross"/>
 </g>
 
 <g id="refs">

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -139,7 +139,7 @@
           marker-end="url(#arrow)"/>
 
     <text x="25" y="142">8</text>
-    <text x="165" y="142">12-na</text>
+    <text x="165" y="142" text-anchor="middle">12-na</text>
     <path d="M  45, 146 L 135, 146"
           marker-end="url(#circle)"/>
 

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -125,25 +125,25 @@
         </marker>
     </defs>
 
-    <text x="28" y="54">8</text>
+    <text x="30" y="54">8</text>
     <path d="M 45, 56 L 495, 56"
           marker-end="url(#arrow)"/>
 
-    <text x="28" y="84">8,
+    <text x="30" y="84">8,
         <tspan fill="red">8u40, 9, 12</tspan></text>
     <path d="M 45, 86 L 495, 86"
           marker-end="url(#arrow)"/>
 
-    <text x="28" y="114">11, 21</text>
+    <text x="30" y="114">11, 21</text>
     <path d="M 135, 116 L 495, 116"
           marker-end="url(#arrow)"/>
 
-    <text x="28" y="144">8</text>
+    <text x="30" y="144">8</text>
     <text x="145" y="144">12-na</text>
     <path d="M  45, 146 L 135, 146"
           marker-end="url(#circle)"/>
 
-    <text x="28" y="174">8</text>
+    <text x="30" y="174">8</text>
     <text x="145" y="174">11-wnf</text>
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -144,7 +144,7 @@
           marker-end="url(#circle)"/>
 
     <text x="25" y="174">8</text>
-    <text x="135" y="174" style="text-anchor: middle">11-wnf</text>
+    <text x="139" y="174" style="text-anchor: middle">11-wnf</text>
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"
           marker-end="url(#circle)"/>

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -144,7 +144,7 @@
           marker-end="url(#circle)"/>
 
     <text x="25" y="174">8</text>
-    <text x="139" y="174" style="text-anchor: middle">11-wnf</text>
+    <text x="165" y="174" style="text-anchor: middle">11-wnf</text>
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"
           marker-end="url(#circle)"/>

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="550" height="200"
      version="1.1"
-     xmlns="http://www.w3.org/2000/svg">
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
     <style><![CDATA[
         rect {
             fill: none;
@@ -147,9 +148,16 @@
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"
           marker-end="url(#circle)"/>
-    <path d="M 132, 173 L 138, 179
-             M 138, 173 L 132, 179"
-          style="stroke: red"/>
+    <g id="redcross">
+        <path d="M 132, 173 L 138, 179
+                 M 138, 173 L 132, 179"
+              style="stroke: red"/>
+    </g>
+    <use
+          x="-90"
+          y="0"
+          xlink:href="#redcross"
+    />
 </g>
 
 <g id="refs">

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -148,7 +148,7 @@
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"
           marker-end="url(#circle)"/>
-    <g id="redcross">
+    <g id="red-cross">
         <path d="M 132, 173 L 138, 179
                  M 138, 173 L 132, 179"
               style="stroke: red"/>
@@ -156,7 +156,8 @@
     <use
           x="-90"
           y="0"
-          xlink:href="#redcross"
+          xlink:href="#red-cross"
+          stroke-width="2"
     />
 </g>
 

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -120,7 +120,7 @@
                 markerHeight="12"
                 orient="auto">
             <circle cx="6" cy="6"
-                    r="3"
+                    r="2"
                     fill="#808080"/>
         </marker>
     </defs>

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -35,7 +35,7 @@
     <text x="15" y="160" transform="rotate(-90 15, 160)">Affects Version</text>
 
 <g id="head">
-    <text x="45" y="15">8</text>
+    <text x="45" y="15" class="lts">8</text>
     <text x="75" y="15">9</text>
     <text x="105" y="15">10</text>
     <text x="135" y="15" class="lts">11</text>

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -106,7 +106,7 @@
                 refX="0"
                 refY="9"
                 markerWidth="20"
-                markerHeight="18"
+                markerHeight="9"
                 orient="auto">
             <path d="M 0 7 L 6 9 L 0 11 Z"
                   fill="#808080"/>

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -125,25 +125,25 @@
         </marker>
     </defs>
 
-    <text x="25" y="54">8</text>
+    <text x="28" y="54">8</text>
     <path d="M 45, 56 L 495, 56"
           marker-end="url(#arrow)"/>
 
-    <text x="25" y="84">8,
+    <text x="28" y="84">8,
         <tspan fill="red">8u40, 9, 12</tspan></text>
     <path d="M 45, 86 L 495, 86"
           marker-end="url(#arrow)"/>
 
-    <text x="25" y="114">11, 21</text>
+    <text x="28" y="114">11, 21</text>
     <path d="M 135, 116 L 495, 116"
           marker-end="url(#arrow)"/>
 
-    <text x="25" y="144">8</text>
+    <text x="28" y="144">8</text>
     <text x="145" y="144">12-na</text>
     <path d="M  45, 146 L 135, 146"
           marker-end="url(#circle)"/>
 
-    <text x="25" y="174">8</text>
+    <text x="28" y="174">8</text>
     <text x="145" y="174">11-wnf</text>
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"

--- a/src/images/affects_versions.svg
+++ b/src/images/affects_versions.svg
@@ -139,12 +139,12 @@
           marker-end="url(#arrow)"/>
 
     <text x="25" y="144">8</text>
-    <text x="165" y="144" text-anchor="middle">12-na</text>
+    <text x="145" y="144">12-na</text>
     <path d="M  45, 146 L 135, 146"
           marker-end="url(#circle)"/>
 
     <text x="25" y="174">8</text>
-    <text x="165" y="174" style="text-anchor: middle">11-wnf</text>
+    <text x="145" y="174">11-wnf</text>
     <path d="M 45, 176 L 315, 176 L 435, 176"
           marker-mid="url(#circle)"
           marker-end="url(#circle)"/>


### PR DESCRIPTION
Update `affects_versions.svg` as per discussion in #149.

1. Make the arrows look better, narrower;
2. Put red cross for version 8 in the case 5 to make it explicit the issue won't be backported to both 11u and 8u;
3. Move all text a few pixels down, closer to the timeline;
4. Left-align `12-na` and `11-wnf` in cases 4 and 5 and display closer to 11 LTS line;
5. Reduce the circle radius for where an issue is fixed;
6. Mark-up 8 as LTS (displayed in bold).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/guide.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/153.diff">https://git.openjdk.org/guide/pull/153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/153#issuecomment-3140672449)
</details>
