### PR TITLE
Update mailman address

### DIFF
--- a/src/guide/mailing-lists.md
+++ b/src/guide/mailing-lists.md
@@ -21,13 +21,13 @@ You must be a member of a list to be able to post to that list. Some lists are m
 There are a few different types of lists. The list name has two parts to explain what the list is intended for, `<name>-<suffix>`. The name often refers to the [Project](https://openjdk.org/bylaws#project) that owns the list or a specific area of interest that the list focuses on. The suffix is explained below. Not all [Projects](https://openjdk.org/bylaws#project) or areas have all types of lists described here.
 
 > `-dev`
-> :    Technical discussions around the implementation of the Project artifacts. This is also where code reviews happen.
+> :    Technical discussions about the implementation of the Project artifacts. This is also where code reviews happen.
 
 > `-use`
-> :    Technical discussions around the usage of the Project artifacts.
+> :    Technical discussions about the usage of the Project artifacts.
 
 > `-discuss`
-> :    General discussions around the [Project](https://openjdk.org/bylaws#project). The special case `discuss@openjdk.org` is used for general discussions around OpenJDK. Discussions around new Project proposals usually happen here.
+> :    General discussions about the [Project](https://openjdk.org/bylaws#project). The special case `discuss@openjdk.org` is used for general discussions around OpenJDK. Discussions around new Project proposals usually happen here.
 
 >  `-changes`
 > :    Changeset notifications from the source code repositories maintained by the [Project](https://openjdk.org/bylaws#project).
@@ -46,7 +46,7 @@ There are a few different types of lists. The list name has two parts to explain
 
 ## Changing your email address
 
-If you need to change your registered email address, or if you have any other problems with the mailing lists, please contact [mailman@openjdk.org](mailto:mailman@openjdk.org).
+If you need to change your registered email address, or if you have any other problems with the mailing lists, please contact [mailman-owner@openjdk.org](mailto:mailman-owner@openjdk.org).
 
 ::: {.box}
 [To the top](#){.boxheader}


### PR DESCRIPTION
Recently, a person sent an email to `mailman-at-openjdk.org` to change the email address as mentioned in the Guide, yet the email was rejected. The rejection email contained another address `mailman-owner-at-openjdk.org` that worked well. Therefore, I suggest updating the mail-man address in the Guide.

I also replaced “discussions _around_” with “discussions _about_”. This is how mailing lists are described on the page that lists all available OpenJDK mailing lists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/154/head:pull/154` \
`$ git checkout pull/154`

Update a local copy of the PR: \
`$ git checkout pull/154` \
`$ git pull https://git.openjdk.org/guide.git pull/154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 154`

View PR using the GUI difftool: \
`$ git pr show -t 154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/154.diff">https://git.openjdk.org/guide/pull/154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/154#issuecomment-3145189702)
</details>
