### PR TITLE
Clarified backport docs

### DIFF
--- a/src/guide/backporting.md
+++ b/src/guide/backporting.md
@@ -72,15 +72,14 @@ If your request to backport a change is denied, but you for some reason already 
 
 The Skara tooling includes support for backports. [The official Skara documentation](https://wiki.openjdk.org/display/SKARA/Backports) describes in detail how to work with the tooling to create backport PRs on [GitHub](https://github.com) or using the CLI tools. As described in the documentation, the [`/backport`](https://wiki.openjdk.org/display/SKARA/Commit+Commands#CommitCommands-/backport) command can be used on a commit or a PR to create the backport PR:
 
-    /backport jdk21u
-    /backport jdk21u-dev
+    /backport :jdk25
 
-In this example we backport a change to the JDK 21 update release. The difference between `jdk21u` and `jdk21u-dev` is that `jdk21u` is used for the two first update releases (21.0.1 and 21.0.2), while `jdk21u-dev` is used for any later update releases of OpenJDK 21. To backport to other update releases, replace `jdk21u` with the corresponding name for the target update repository.
+In this example we backport the change to a stabilization branch, in this case JDK 25.
 
-    /backport jdk jdk23
-    /backport :jdk23
+    /backport jdk25u
+    /backport jdk25u-dev
 
-In this second example we backport the change to a stabilization branch, in this case JDK 23. As before `jdk` is the name of the target repository, and `jdk23` is the name of the stabilization branch. Using the colon syntax is a shortcut.
+In this second example we backport a change to the JDK 25 update release. The difference between `jdk25u` and `jdk25u-dev` is that `jdk25u` is used for the two first update releases (25.0.1 and 25.0.2), while `jdk25u-dev` is used for any later OpenJDK JDK 25 update releases. To backport to other update releases, replace `jdk25u` with the corresponding name for the target update repository.
 
 Using the `/backport` command is the recommended way to perform backports as the tooling will automatically handle all the necessary steps in the background. If a backport PR is manually created, set the PR title to `Backport <original commit hash>`. This ensures that the bots will recognize it as a backport as opposed to a main fix specifically targeting an older release. One can tell whether or not the bots recognized a PR as a backport by the [backport]{.label} label being added if it's recognized.
 


### PR DESCRIPTION
Explaining the difference between jdk21u and jdk21u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [bc67d331](https://git.openjdk.org/guide/pull/158/files/bc67d331f4438c2899a4464155c8b976746edcb9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/guide.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/158.diff">https://git.openjdk.org/guide/pull/158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/158#issuecomment-3207653425)
</details>
