### PR TITLE
Use better JBS link for searches

### DIFF
--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -22,7 +22,7 @@ If you suspect that the issue is a vulnerability, **don't file a JBS issue!** In
 A few things to keep in mind when filing an issue:
 
 * Before filing, verify that there isn't an open issue already filed.
-  * Search [JBS](https://bugs.openjdk.org/issues/?jql=) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
+  * Search [JBS](https://bugs.openjdk.org/issues/?jql=project%20%3D%20JDK) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
   * If you find a similar issue that was closed as [Cannot Reproduce]{.jbs-value} then it may be appropriate to re-open that one - if you don't have direct access to JBS you can file a bug using the [Bug Report Tool](https://bugreport.java.com/) requesting that it be reopened.
 * Set a relevant [Component/s]{.jbs-field} for the issue.
   * If you are unsure what component to choose, see [Code Owners](#code-owners) for guidance.

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -22,7 +22,7 @@ If you suspect that the issue is a vulnerability, **don't file a JBS issue!** In
 A few things to keep in mind when filing an issue:
 
 * Before filing, verify that there isn't an open issue already filed.
-  * Search [JBS](https://bugs.openjdk.org/) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
+  * Search [JBS](https://bugs.openjdk.org/issues/?jql=) for things like the name of the failing test, assert messages, the name of the source code file where a crash occurred etc.
   * If you find a similar issue that was closed as [Cannot Reproduce]{.jbs-value} then it may be appropriate to re-open that one - if you don't have direct access to JBS you can file a bug using the [Bug Report Tool](https://bugreport.java.com/) requesting that it be reopened.
 * Set a relevant [Component/s]{.jbs-field} for the issue.
   * If you are unsure what component to choose, see [Code Owners](#code-owners) for guidance.


### PR DESCRIPTION
Jira no longer allows searches via the main landing page (text box in top right hand corner) if you're logged out of the system

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - no project role)
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.org/guide.git pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/171.diff">https://git.openjdk.org/guide/pull/171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/171#issuecomment-3974194878)
</details>
