### PR TITLE
Remove jvmci and graal references from the guide

### DIFF
--- a/src/guide/code-owners.md
+++ b/src/guide/code-owners.md
@@ -47,7 +47,6 @@ This list is intended to make it easier to identify which email list to include 
     * [include](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/include) - HotSpot
     * [interpreter](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/interpreter) - Runtime
     * [jfr](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/jfr) - JFR
-    * [jvmci](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/jvmci) - Compiler
     * [libadt](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/libadt) - Compiler
     * [logging](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/logging) - Runtime
     * [memory](https://github.com/openjdk/jdk/tree/master/src/hotspot/share/memory) - GC, Runtime
@@ -172,8 +171,6 @@ This list is intended to make it easier to identify which email list to include 
 * [jdk.crypto.mscapi](https://github.com/openjdk/jdk/tree/master/src/jdk.crypto.mscapi) - Security
 * [jdk.dynalink](https://github.com/openjdk/jdk/tree/master/src/jdk.dynalink) - Tools
 * [jdk.editpad](https://github.com/openjdk/jdk/tree/master/src/jdk.editpad) - JShell
-* [jdk.graal.compiler](https://github.com/openjdk/jdk/tree/master/src/jdk.graal.compiler) - Compiler
-* [jdk.graal.compiler.management](https://github.com/openjdk/jdk/tree/master/src/jdk.graal.compiler.management) - Compiler
 * [jdk.hotspot.agent](https://github.com/openjdk/jdk/tree/master/src/jdk.hotspot.agent) - Serviceability
 * [jdk.httpserver](https://github.com/openjdk/jdk/tree/master/src/jdk.httpserver) - Net
 * [jdk.incubator.vector](https://github.com/openjdk/jdk/tree/master/src/jdk.incubator.vector) - Compiler
@@ -182,7 +179,6 @@ This list is intended to make it easier to identify which email list to include 
 * [jdk.internal.le](https://github.com/openjdk/jdk/tree/master/src/jdk.internal.le) - JShell
 * [jdk.internal.md](https://github.com/openjdk/jdk/tree/master/src/jdk.internal.md) - Tools
 * [jdk.internal.opt](https://github.com/openjdk/jdk/tree/master/src/jdk.internal.opt) - Tools
-* [jdk.internal.vm.ci](https://github.com/openjdk/jdk/tree/master/src/jdk.internal.vm.ci) - Compiler
 * [jdk.jartool](https://github.com/openjdk/jdk/tree/master/src/jdk.jartool) - Tools
 * [jdk.javadoc](https://github.com/openjdk/jdk/tree/master/src/jdk.javadoc) - Javadoc
 * [jdk.jcmd](https://github.com/openjdk/jdk/tree/master/src/jdk.jcmd) - Serviceability

--- a/src/guide/code-owners.md
+++ b/src/guide/code-owners.md
@@ -218,6 +218,7 @@ This list is intended to make it easier to identify which email list to include 
   * `*.jdk` – Compiler (Removed in [10](https://bugs.openjdk.org/browse/JDK-8187443))
   * share
     * `aot` – Compiler (Removed in [17](https://bugs.openjdk.org/browse/JDK-8263327))
+    * `jvmci` – Compiler (Removed in [27](https://bugs.openjdk.org/browse/JDK-8382582))
     * `shark` – Compiler (Removed in [10](https://bugs.openjdk.org/browse/JDK-8171853))
     * `trace` – Runtime (Removed in [11](https://bugs.openjdk.org/browse/JDK-8199712))
 * java.base
@@ -226,7 +227,10 @@ This list is intended to make it easier to identify which email list to include 
 * `jdk.aot` – Compiler (Removed in [17](https://bugs.openjdk.org/browse/JDK-8263327))
 * `jdk.crypto.ucrypto` – Security (Removed in [12](https://bugs.openjdk.org/browse/JDK-8241787))
   * only available on Solaris
+* `jdk.graal.compiler` – Compiler (Removed in [27](https://bugs.openjdk.org/browse/JDK-8382582))
+* `jdk.graal.compiler.management` – Compiler (Removed in [27](https://bugs.openjdk.org/browse/JDK-8382582))
 * `jdk.incubator.concurrent` – Core Libs (Removed in [21](https://bugs.openjdk.org/browse/JDK-8306647))
+* `jdk.internal.vm.ci` – Compiler (Removed in [27](https://bugs.openjdk.org/browse/JDK-8382582))
 * `jdk.internal.vm.compiler` – Compiler (Removed in [22](https://bugs.openjdk.org/browse/JDK-8318027))
 * `jdk.internal.vm.compiler.management` – Compiler (Removed in [22](https://bugs.openjdk.org/browse/JDK-8318027))
 * `jdk.pack` – Tools (Removed in [14](https://bugs.openjdk.org/browse/JDK-8234596))

--- a/src/guide/jbs-jdk-bug-system.md
+++ b/src/guide/jbs-jdk-bug-system.md
@@ -376,7 +376,7 @@ This table contains some frequently used JBS labels and their meaning. Please he
   <tr>
     <td class="dictionary">[*(Area)*[-related]{.jbs-label}]{#area-related}</td>
     <td class="dictionary">
-      Used to indicate that an issue is related to a specific area (usually a feature or [Project](https://openjdk.org/bylaws#project)). This label doesn't indicate ownership of the issue. E.g., [graal-related]{.jbs-label}, [testcolo-related]{.jbs-label}, [doc-related]{.jbs-label}
+      Used to indicate that an issue is related to a specific area (usually a feature or [Project](https://openjdk.org/bylaws#project)). This label doesn't indicate ownership of the issue. E.g., [testcolo-related]{.jbs-label}, [doc-related]{.jbs-label}
     </td>
   </tr>
   <!-- Release -->
@@ -544,18 +544,6 @@ This table contains some frequently used JBS labels and their meaning. Please he
       Note that ZGC breaks this pattern and uses the label [zgc]{.jbs-label}.
     </td>
   </tr>
-  <tr>
-    <td class="dictionary">[[graal]{.jbs-label}]{#graal}</td>
-    <td class="dictionary">
-      Used to indicate that this is a Graal issue. (Something that needs to be fixed in Graal rather than in the JDK.)
-    </td>
-  </tr>
-  <tr>
-    <td class="dictionary">[[graal-integration]{.jbs-label}]{#graal-integration}</td>
-    <td class="dictionary">
-      Reserved for Graal integration umbrella bugs. The automated integration script will break if this label is used for other bugs.
-    </td>
-  </tr>
   <!-- H -->
   <tr>
     <td class="dictionary">[[hgupdate-sync]{.jbs-label}]{#hgupdate-sync}</td>
@@ -612,12 +600,6 @@ This table contains some frequently used JBS labels and their meaning. Please he
     <td class="dictionary">[[jep-superseded]{.jbs-label}]{#jep-superseded}</td>
     <td class="dictionary">
       Used to tag JEPs that have been superseded by a newer version of the JEP.
-    </td>
-  </tr>
-  <tr>
-    <td class="dictionary">[[jvmci]{.jbs-label}]{#jvmci}</td>
-    <td class="dictionary">
-      Used to identify issues in the JVM Compiler Interface.
     </td>
   </tr>
   <!-- K -->

--- a/src/guide/testing-the-jdk.md
+++ b/src/guide/testing-the-jdk.md
@@ -198,17 +198,14 @@ There are actually several ProblemList files to choose from in the JDK. Their lo
 ~~~
 test/hotspot/jtreg/ProblemList.txt
 test/hotspot/jtreg/ProblemList-aot.txt
-test/hotspot/jtreg/ProblemList-graal.txt
 test/hotspot/jtreg/ProblemList-non-cds-mode.txt
 test/hotspot/jtreg/ProblemList-Xcomp.txt
 test/hotspot/jtreg/ProblemList-zgc.txt
 test/jaxp/ProblemList.txt
 test/jdk/ProblemList.txt
 test/jdk/ProblemList-aot.txt
-test/jdk/ProblemList-graal.txt
 test/jdk/ProblemList-Xcomp.txt
 test/langtools/ProblemList.txt
-test/langtools/ProblemList-graal.txt
 test/lib-test/ProblemList.txt
 ~~~
 


### PR DESCRIPTION
With the [removal of JVMCI and Graal from openJDK](https://github.com/openjdk/jdk/pull/30834), we should also remove such references from the Guide. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [6d7a9a0a](https://git.openjdk.org/guide/pull/174/files/6d7a9a0a19af3d327413572cd5592c05bb6fba9e)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - no project role) ⚠️ Review applies to [6d7a9a0a](https://git.openjdk.org/guide/pull/174/files/6d7a9a0a19af3d327413572cd5592c05bb6fba9e)
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/guide.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/guide.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/guide/pull/174.diff">https://git.openjdk.org/guide/pull/174.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/guide/pull/174#issuecomment-4546752100)
</details>
